### PR TITLE
Update versions of requirements via pip-compile.

### DIFF
--- a/config_models/__init__.py
+++ b/config_models/__init__.py
@@ -4,6 +4,6 @@ Configuration models for Django allowing config management with auditing.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 default_app_config = 'config_models.apps.ConfigModelsConfig'  # pylint: disable=invalid-name

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
 # Core requirements for using this application
 
-Django                    # Web application framework
-djangorestframework
+Django>=1.8,<1.10                    # Web application framework
+djangorestframework>=3.2.3

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
 # Core requirements for using this application
 
 Django>=1.8,<1.10                    # Web application framework
-djangorestframework>=3.2.3
+djangorestframework>=3.2.3,<3.3.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,5 +4,5 @@
 #
 #    pip-compile --output-file requirements/base.txt requirements/base.in
 #
-Django==1.10.2
-djangorestframework==3.4.7
+Django==1.9.12
+djangorestframework==3.5.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,4 +5,4 @@
 #    pip-compile --output-file requirements/base.txt requirements/base.in
 #
 Django==1.9.12
-djangorestframework==3.5.4
+djangorestframework==3.2.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,34 +5,40 @@
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in
 #
 -e git+https://github.com/edx/i18n-tools.git@v0.3.2#egg=i18n_tools==0.3.2
+appdirs==1.4.0            # via setuptools
 args==0.1.0               # via clint
-astroid==1.4.8            # via pylint, pylint-celery, pylint-plugin-utils
-click==6.6                # via pip-tools
+astroid==1.4.9            # via pylint, pylint-celery, pylint-plugin-utils
+backports.functools-lru-cache==1.3  # via pylint
+click==6.7                # via pip-tools
 clint==0.5.1              # via twine
-colorama==0.3.7           # via pylint
-ddt==1.1.0
-edx-lint==0.5.1
+configparser==3.5.0       # via pylint
+ddt==1.1.1
+edx-lint==0.5.2
 first==2.0.1              # via pip-tools
+isort==4.2.5              # via pylint
 lazy-object-proxy==1.2.2  # via astroid
-path.py==8.2.1
-pip-tools==1.7.0
-pkginfo==1.3.2            # via twine
-pluggy==0.3.1             # via tox
-polib==1.0.7
-py==1.4.31                # via tox
+mccabe==0.6.1             # via pylint
+packaging==16.8           # via setuptools
+path.py==10.1
+pip-tools==1.8.0
+pkginfo==1.4.1            # via twine
+pluggy==0.4.0             # via tox
+polib==1.0.8
+py==1.4.32                # via tox
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.4  # via pylint-celery, pylint-django
-pylint==1.5.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pytz==2016.7
+pylint==1.6.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pyparsing==2.1.10         # via packaging
+pytz==2016.10
 pyYaml==3.12
-requests-toolbelt==0.7.0  # via twine
-requests==2.11.1          # via requests-toolbelt, twine
-six==1.10.0               # via astroid, edx-lint, pip-tools, pylint
-tox-battery==0.2
-tox==2.3.1
+requests-toolbelt==0.7.1  # via twine
+requests==2.13.0          # via requests-toolbelt, twine
+six==1.10.0               # via astroid, edx-lint, packaging, pip-tools, pylint, setuptools
+tox-battery==0.3
+tox==2.6.0
 twine==1.8.1
-virtualenv==15.0.3        # via tox
+virtualenv==15.1.0        # via tox
 wheel==0.29.0
 wrapt==1.10.8             # via astroid
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,16 +6,17 @@
 #
 alabaster==0.7.9          # via sphinx
 babel==2.3.4              # via sphinx
-bleach==1.4.3             # via readme-renderer
-docutils==0.12            # via readme-renderer, sphinx
+bleach==1.5.0             # via readme-renderer
+docutils==0.13.1          # via readme-renderer, sphinx
 html5lib==0.9999999       # via bleach
 imagesize==0.7.1          # via sphinx
-Jinja2==2.8               # via sphinx
+Jinja2==2.9.5             # via sphinx
 MarkupSafe==0.23          # via jinja2
-Pygments==2.1.3           # via readme-renderer, sphinx
-pytz==2016.7              # via babel
-readme-renderer==0.7.0
+Pygments==2.2.0           # via readme-renderer, sphinx
+pytz==2016.10             # via babel
+readme-renderer==16.0
+requests==2.13.0          # via sphinx
 six==1.10.0               # via bleach, html5lib, readme-renderer, sphinx
 snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.1.9
-Sphinx==1.4.8             # via sphinx-rtd-theme
+Sphinx==1.5.2             # via sphinx-rtd-theme

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,24 +4,28 @@
 #
 #    pip-compile --output-file requirements/quality.txt requirements/quality.in
 #
+appdirs==1.4.0            # via setuptools
 argparse==1.4.0           # via caniusepython3
-astroid==1.4.8            # via pylint, pylint-celery, pylint-plugin-utils
-caniusepython3==4.0.0
-colorama==0.3.7           # via pylint
+astroid==1.4.9            # via pylint, pylint-celery, pylint-plugin-utils
+backports.functools-lru-cache==1.3  # via caniusepython3, pylint
+caniusepython3==5.0.0
+configparser==3.5.0       # via pylint
 distlib==0.2.4            # via caniusepython3
-edx-lint==0.5.1
+edx-lint==0.5.2
 futures==3.0.5            # via caniusepython3
+isort==4.2.5              # via pylint
 lazy-object-proxy==1.2.2  # via astroid
-packaging==16.7           # via caniusepython3
-pycodestyle==2.0.0
+mccabe==0.6.1             # via pylint
+packaging==16.8           # via caniusepython3, setuptools
+pycodestyle==2.3.1
 pydocstyle==1.1.1
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.4  # via pylint-celery, pylint-django
-pylint==1.5.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.1.9          # via packaging
-requests==2.11.1          # via caniusepython3
-six==1.10.0               # via astroid, edx-lint, packaging, pylint
+pylint==1.6.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pyparsing==2.1.10         # via packaging
+requests==2.13.0          # via caniusepython3
+six==1.10.0               # via astroid, edx-lint, packaging, pylint, setuptools
 wrapt==1.10.8             # via astroid
 
 # The following packages are commented out because they are

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,7 @@
 appdirs==1.4.0            # via setuptools
 coverage==4.3.4           # via pytest-cov
 ddt==1.1.1
-djangorestframework==3.5.4
+djangorestframework==3.2.5
 freezegun==0.3.8
 funcsigs==1.0.2           # via mock
 mock==2.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,17 +4,24 @@
 #
 #    pip-compile --output-file requirements/test.txt requirements/base.in requirements/test.in
 #
-coverage==4.2             # via pytest-cov
-ddt==1.1.0
-djangorestframework==3.4.7
-freezegun==0.3.7
+appdirs==1.4.0            # via setuptools
+coverage==4.3.4           # via pytest-cov
+ddt==1.1.1
+djangorestframework==3.5.4
+freezegun==0.3.8
 funcsigs==1.0.2           # via mock
 mock==2.0.0
+packaging==16.8           # via setuptools
 pbr==1.10.0               # via mock
-py==1.4.31                # via pytest, pytest-catchlog
+py==1.4.32                # via pytest, pytest-catchlog
+pyparsing==2.1.10         # via packaging
 pytest-catchlog==1.2.2
-pytest-cov==2.3.1
-pytest-django==3.0.0
-pytest==3.0.3             # via pytest-catchlog, pytest-cov, pytest-django
-python-dateutil==2.5.3    # via freezegun
-six==1.10.0               # via freezegun, mock, python-dateutil
+pytest-cov==2.4.0
+pytest-django==3.1.2
+pytest==3.0.6             # via pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.6.0    # via freezegun
+six==1.10.0               # via freezegun, mock, packaging, python-dateutil, setuptools
+
+# The following packages are commented out because they are
+# considered to be unsafe in a requirements file:
+# setuptools                # via pytest

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -6,10 +6,10 @@
 #
 argparse==1.4.0           # via codecov
 codecov==2.0.5
-coverage==4.2             # via codecov
-pluggy==0.3.1             # via tox
-py==1.4.31                # via tox
-requests==2.11.1          # via codecov
-tox-battery==0.2
-tox==2.3.1
-virtualenv==15.0.3        # via tox
+coverage==4.3.4           # via codecov
+pluggy==0.4.0             # via tox
+py==1.4.32                # via tox
+requests==2.13.0          # via codecov
+tox-battery==0.3
+tox==2.6.0
+virtualenv==15.1.0        # via tox


### PR DESCRIPTION
The last version failed tests due to outdated/mismatched requirements.

@cpennington @jmbowman Please review.