### PR TITLE
Add explicit package name to tox py.test command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     django19: Django>=1.9,<1.10
     -r{toxinidir}/requirements/test.txt
 commands =
-    py.test {posargs}
+    py.test config_models {posargs}
 
 [testenv:docs]
 setenv =


### PR DESCRIPTION
If there is, for example, a virtualenv setup inside the project's root
directory, running tox will result in errors. This happens due to
py.test trying to execute the tests for the packages inside the
virtualenv.

By explicitly naming the package on which tests should be run, this
problem is mitigated.

Fixes #9 