### PR TITLE
Add warm_cache method and query_db kwarg on others

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,17 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-[0.1.9] - 2017-08-07
+[0.2.0] - 2017-10-10
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Added
+-----
+* Add warm_cache method that fills the cache with all instances of a ConfigurationModel.
+* Add query_db option to current and is_enabled methods that triggers whether
+  they will query the database on a cache miss.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[0.1.9] - 2017-08-07
 
 Changed
 -------

--- a/config_models/__init__.py
+++ b/config_models/__init__.py
@@ -4,6 +4,6 @@ Configuration models for Django allowing config management with auditing.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.9'
+__version__ = '0.2.0'
 
 default_app_config = 'config_models.apps.ConfigModelsConfig'  # pylint: disable=invalid-name

--- a/config_models/tests/test_config_models.py
+++ b/config_models/tests/test_config_models.py
@@ -99,6 +99,21 @@ class ConfigurationModelTests(TestCase):
 
         mock_cache.set.assert_called_with(ExampleConfig.cache_key_name(), first, 300)
 
+    def test_cache_get_with_no_db(self, mock_cache):
+        mock_cache.get.return_value = None
+        with self.assertNumQueries(0):
+            current = ExampleConfig.current(query_db=False)
+        self.assertEquals(current.int_field, 10)
+        self.assertEquals(current.string_field, '')
+
+    def test_warm_cache(self, mock_cache):
+        first = ExampleConfig.objects.create(string_field='first')
+        second = ExampleConfig.objects.create(string_field='second')
+        ExampleConfig.warm_cache()
+
+        mock_cache.set.assert_any_call(ExampleConfig.cache_key_name(), first, 300)
+        mock_cache.set.assert_any_call(ExampleConfig.cache_key_name(), second, 300)
+
     def test_active_annotation(self, mock_cache):
         mock_cache.get.return_value = None
 

--- a/config_models/tests/test_config_models.py
+++ b/config_models/tests/test_config_models.py
@@ -101,18 +101,38 @@ class ConfigurationModelTests(TestCase):
 
     def test_cache_get_with_no_db(self, mock_cache):
         mock_cache.get.return_value = None
+
         with self.assertNumQueries(0):
             current = ExampleConfig.current(query_db=False)
+
         self.assertEquals(current.int_field, 10)
         self.assertEquals(current.string_field, '')
 
     def test_warm_cache(self, mock_cache):
         first = ExampleConfig.objects.create(string_field='first')
         second = ExampleConfig.objects.create(string_field='second')
+
         ExampleConfig.warm_cache()
 
         mock_cache.set.assert_any_call(ExampleConfig.cache_key_name(), first, 300)
         mock_cache.set.assert_any_call(ExampleConfig.cache_key_name(), second, 300)
+
+    def test_is_enabled(self, __):
+        first = ExampleConfig.objects.create(string_field='first', enabled=True)
+        first.save()
+
+        current = ExampleConfig.is_enabled()
+
+        self.assertTrue(current)
+
+    def test_is_enabled_with_no_db(self, mock_cache):
+        mock_cache.get.return_value = None
+        ExampleConfig.objects.create(string_field='first', enabled=True)
+
+        with self.assertNumQueries(0):
+            current = ExampleConfig.is_enabled(query_db=False)
+
+        self.assertFalse(current)
 
     def test_active_annotation(self, mock_cache):
         mock_cache.get.return_value = None


### PR DESCRIPTION
I ran into a case where we were making hundreds of separate ConfigurationModel queries, and I thought it would be useful to query them all in one query up front, save them in the cache, and add an option so that further calls to `current()` will not hit the DB.

@cpennington @mulby @sandroroux