### PR TITLE
Fixing compatibility issues with Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
-- 2.7
+  - 2.7
+  - 3.6
 env:
 - TOXENV=django18
 - TOXENV=django19
@@ -8,6 +9,10 @@ env:
 - TOXENV=django111
 matrix:
   include:
+  - python: 3.6
+    env: TOXENV=quality
+  - python: 3.6
+    env: TOXENV=docs
   - python: 2.7
     env: TOXENV=quality
   - python: 2.7
@@ -26,5 +31,7 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
+    python: 3.6
+    condition: '$TOXENV = django111'
   password:
     secure: Mk/97Np4pwZte72JOOiJtv/nKJR+JBvtOkEnvWcMWVhJ36n4/nVOlzX+/3kA8CjIHJQHF6LGbx+XPAcTxBqVzJW8EjN94kFitLsb6Xvl/ucADElGfXyN2wXZODtv8SFFY711MEmILqrd8E58JLhbzD+mcvngkS3DCT0msZB224zRn6w+6tmfatW6D4oFqisJnULUSRKRvZiRgrtyweMcXgLaEQAF4Lc4oO9/Nfq9pX3zqH/y5GyuRJlVQPGn32gvZtiiulMfJYQfCX/9/swPYe44Nv8jACaPgvILVGJ9UeltUIuif1HHw3S2isJq9ZFA8BAcTOsjdDRazem0QHxKdO5ZF3Eqtgcr4LA3QtGIcIuUP+prn4lg71HrPIs4TMQzDozpmwF0lr+IYYbeTO9QgBjcbrx7Nc5SMbr5wvSbd9EGOIlZ6shjS1H2Z78OYBiuRmZW5FuF2QDx1qa4kBdtQtewS+IMpUzhwXs6mN6Rbz+Mkm7xSjP8TeZSmcs20zBp3sLirZc0ypep8GaPjKwJrb7+vai40u4t2/rJQKsoDVUmL/FjLmwazQ3Dacgsr+44MZMlw7uLOynP72P24h6MGv6F9k2FcChVpQ9+DjldU7FDVUZLdgXn8oiO8HpfPAYKqjRLOy+q4ed2zqfBw4w5JCV9A02j50WNi0ZeEqpvnDk=

--- a/config_models/management/commands/populate_model.py
+++ b/config_models/management/commands/populate_model.py
@@ -4,6 +4,7 @@ Populates a ConfigurationModel by deserializing JSON data contained in a file.
 from __future__ import unicode_literals, absolute_import
 
 import os
+import io
 
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import ugettext_lazy as _
@@ -74,7 +75,7 @@ class Command(BaseCommand):
             raise CommandError(_("File {0} does not exist").format(json_file))  # pylint: disable=no-member
 
         self.stdout.write(_("Importing JSON data from file {0}").format(json_file))  # pylint: disable=no-member
-        with open(json_file) as data:  # pylint: disable=open-builtin
+        with io.open(json_file, "rb") as data:
             created_entries = deserialize_json(data, options['username'])
             # pylint: disable=no-member
             self.stdout.write(_("Import complete, {0} new entries created").format(created_entries))

--- a/config_models/models.py
+++ b/config_models/models.py
@@ -7,9 +7,9 @@ from django.db import connection, models
 from django.conf import settings
 from django.core.cache import caches, InvalidCacheBackendError
 from django.utils.translation import ugettext_lazy as _
+from django.utils import six
 
 from rest_framework.utils import model_meta
-
 # Config model values are cached. The caching backend configuration used has implications for how the values
 # are changed/queried in an active release. When a new key/value is saved, its current cached value is cleared
 # via deletion from the cache. Otherwise, depending on the cache backend configuration *and* on the value of
@@ -137,7 +137,7 @@ class ConfigurationModel(models.Model):
                     "cache_key_name() takes exactly {} arguments ({} given)".format(len(cls.KEY_FIELDS), len(args))
                 )
             # pylint: disable=unicode-builtin
-            return 'configuration/{}/current/{}'.format(cls.__name__, ','.join(unicode(arg) for arg in args))
+            return 'configuration/{}/current/{}'.format(cls.__name__, ','.join(six.text_type(arg) for arg in args))
         else:
             return 'configuration/{}/current'.format(cls.__name__)
 

--- a/config_models/tests/test_config_models.py
+++ b/config_models/tests/test_config_models.py
@@ -8,6 +8,7 @@ import ddt
 from django.contrib.auth.models import User
 from django.db import models
 from django.test import TestCase
+from django.utils import six
 from rest_framework.test import APIRequestFactory
 
 from freezegun import freeze_time
@@ -17,6 +18,8 @@ from config_models.models import ConfigurationModel
 from config_models.views import ConfigurationModelCurrentAPIView
 
 
+# pylint: disable=model-missing-unicode
+@six.python_2_unicode_compatible
 class ExampleConfig(ConfigurationModel):
     """
     Test model for testing ``ConfigurationModels``.
@@ -26,12 +29,14 @@ class ExampleConfig(ConfigurationModel):
     string_field = models.TextField()
     int_field = models.IntegerField(default=10)
 
-    def __unicode__(self):
+    def __str__(self):
         return "ExampleConfig(enabled={}, string_field={}, int_field={})".format(
             self.enabled, self.string_field, self.int_field
         )
 
 
+# pylint: disable=model-missing-unicode
+@six.python_2_unicode_compatible
 class ManyToManyExampleConfig(ConfigurationModel):
     """
     Test model configuration with a many-to-many field.
@@ -41,7 +46,7 @@ class ManyToManyExampleConfig(ConfigurationModel):
     string_field = models.TextField()
     many_user_field = models.ManyToManyField(User, related_name='topic_many_user_field')
 
-    def __unicode__(self):
+    def __str__(self):
         return "ManyToManyExampleConfig(enabled={}, string_field={})".format(self.enabled, self.string_field)
 
 
@@ -60,19 +65,19 @@ class ConfigurationModelTests(TestCase):
         mock_cache.delete.assert_called_with(ExampleConfig.cache_key_name())
 
     def test_cache_key_name(self, __):
-        self.assertEquals(ExampleConfig.cache_key_name(), 'configuration/ExampleConfig/current')
+        self.assertEqual(ExampleConfig.cache_key_name(), 'configuration/ExampleConfig/current')
 
     def test_no_config_empty_cache(self, mock_cache):
         mock_cache.get.return_value = None
 
         current = ExampleConfig.current()
-        self.assertEquals(current.int_field, 10)
-        self.assertEquals(current.string_field, '')
+        self.assertEqual(current.int_field, 10)
+        self.assertEqual(current.string_field, '')
         mock_cache.set.assert_called_with(ExampleConfig.cache_key_name(), current, 300)
 
     def test_no_config_full_cache(self, mock_cache):
         current = ExampleConfig.current()
-        self.assertEquals(current, mock_cache.get.return_value)
+        self.assertEqual(current, mock_cache.get.return_value)
 
     def test_config_ordering(self, mock_cache):
         mock_cache.get.return_value = None
@@ -86,7 +91,7 @@ class ConfigurationModelTests(TestCase):
         second.string_field = 'second'
         second.save()
 
-        self.assertEquals(ExampleConfig.current().string_field, 'second')
+        self.assertEqual(ExampleConfig.current().string_field, 'second')
 
     def test_cache_set(self, mock_cache):
         mock_cache.get.return_value = None
@@ -120,7 +125,7 @@ class ConfigurationModelTests(TestCase):
         config.string_field = 'second'
         config.save()
 
-        self.assertEquals(2, ExampleConfig.objects.all().count())
+        self.assertEqual(2, ExampleConfig.objects.all().count())
 
     def test_equality(self, mock_cache):
         mock_cache.get.return_value = None
@@ -181,6 +186,8 @@ class ConfigurationModelTests(TestCase):
         )
 
 
+# pylint: disable=model-missing-unicode
+@six.python_2_unicode_compatible
 class ExampleKeyedConfig(ConfigurationModel):
     """
     Test model for testing ``ConfigurationModels`` with keyed configuration.
@@ -197,7 +204,7 @@ class ExampleKeyedConfig(ConfigurationModel):
     string_field = models.TextField()
     int_field = models.IntegerField(default=10)
 
-    def __unicode__(self):
+    def __str__(self):
         return "ExampleKeyedConfig(enabled={}, left={}, right={}, string_field={}, int_field={})".format(
             self.enabled, self.left, self.right, self.string_field, self.int_field
         )
@@ -217,7 +224,7 @@ class KeyedConfigurationModelTests(TestCase):
     @ddt.data(('a', 'b'), ('c', 'd'))
     @ddt.unpack
     def test_cache_key_name(self, left, right, _mock_cache):
-        self.assertEquals(
+        self.assertEqual(
             ExampleKeyedConfig.cache_key_name(left, right),
             'configuration/ExampleKeyedConfig/current/{},{}'.format(left, right)
         )
@@ -229,7 +236,7 @@ class KeyedConfigurationModelTests(TestCase):
     )
     @ddt.unpack
     def test_key_values_cache_key_name(self, args, expected_key, _mock_cache):
-        self.assertEquals(
+        self.assertEqual(
             ExampleKeyedConfig.key_values_cache_key_name(*args),
             'configuration/ExampleKeyedConfig/key_values/{}'.format(expected_key))
 
@@ -239,15 +246,15 @@ class KeyedConfigurationModelTests(TestCase):
         mock_cache.get.return_value = None
 
         current = ExampleKeyedConfig.current(left, right)
-        self.assertEquals(current.int_field, 10)
-        self.assertEquals(current.string_field, '')
+        self.assertEqual(current.int_field, 10)
+        self.assertEqual(current.string_field, '')
         mock_cache.set.assert_called_with(ExampleKeyedConfig.cache_key_name(left, right), current, 300)
 
     @ddt.data(('a', 'b'), ('c', 'd'))
     @ddt.unpack
     def test_no_config_full_cache(self, left, right, mock_cache):
         current = ExampleKeyedConfig.current(left, right)
-        self.assertEquals(current, mock_cache.get.return_value)
+        self.assertEqual(current, mock_cache.get.return_value)
 
     def test_config_ordering(self, mock_cache):
         mock_cache.get.return_value = None
@@ -280,8 +287,8 @@ class KeyedConfigurationModelTests(TestCase):
             string_field='second_b',
         ).save()
 
-        self.assertEquals(ExampleKeyedConfig.current('left_a', 'right_a').string_field, 'second_a')
-        self.assertEquals(ExampleKeyedConfig.current('left_b', 'right_b').string_field, 'second_b')
+        self.assertEqual(ExampleKeyedConfig.current('left_a', 'right_a').string_field, 'second_a')
+        self.assertEqual(ExampleKeyedConfig.current('left_b', 'right_b').string_field, 'second_b')
 
     def test_cache_set(self, mock_cache):
         mock_cache.get.return_value = None
@@ -309,11 +316,11 @@ class KeyedConfigurationModelTests(TestCase):
         ExampleKeyedConfig(left='left_b', right='right_b', changed_by=self.user).save()
 
         unique_key_pairs = ExampleKeyedConfig.key_values()
-        self.assertEquals(len(unique_key_pairs), 2)
-        self.assertEquals(set(unique_key_pairs), set([('left_a', 'right_a'), ('left_b', 'right_b')]))
+        self.assertEqual(len(unique_key_pairs), 2)
+        self.assertEqual(set(unique_key_pairs), set([('left_a', 'right_a'), ('left_b', 'right_b')]))
         unique_left_keys = ExampleKeyedConfig.key_values('left', flat=True)
-        self.assertEquals(len(unique_left_keys), 2)
-        self.assertEquals(set(unique_left_keys), set(['left_a', 'left_b']))
+        self.assertEqual(len(unique_left_keys), 2)
+        self.assertEqual(set(unique_left_keys), set(['left_a', 'left_b']))
 
     def test_key_string_values(self, mock_cache):
         """ Ensure str() vs unicode() doesn't cause duplicate cache entries """
@@ -369,12 +376,12 @@ class KeyedConfigurationModelTests(TestCase):
 
     def test_key_values_cache(self, mock_cache):
         mock_cache.get.return_value = None
-        self.assertEquals(ExampleKeyedConfig.key_values(), [])
+        self.assertEqual(ExampleKeyedConfig.key_values(), [])
         mock_cache.set.assert_called_with(ExampleKeyedConfig.key_values_cache_key_name(), [], 300)
 
         fake_result = [('a', 'b'), ('c', 'd')]
         mock_cache.get.return_value = fake_result
-        self.assertEquals(ExampleKeyedConfig.key_values(), fake_result)
+        self.assertEqual(ExampleKeyedConfig.key_values(), fake_result)
 
     def test_equality(self, mock_cache):
         mock_cache.get.return_value = None
@@ -440,42 +447,42 @@ class ConfigurationModelAPITests(TestCase):
         self.addCleanup(patcher.stop)
 
     def test_insert(self):
-        self.assertEquals("", ExampleConfig.current().string_field)
+        self.assertEqual("", ExampleConfig.current().string_field)
 
         request = self.factory.post('/config/ExampleConfig', {"string_field": "string_value"})
         request.user = self.user
         __ = self.current_view(request)
 
-        self.assertEquals("string_value", ExampleConfig.current().string_field)
-        self.assertEquals(self.user, ExampleConfig.current().changed_by)
+        self.assertEqual("string_value", ExampleConfig.current().string_field)
+        self.assertEqual(self.user, ExampleConfig.current().changed_by)
 
     def test_multiple_inserts(self):
-        for i in xrange(3):  # pylint: disable=xrange-builtin
-            self.assertEquals(i, ExampleConfig.objects.all().count())
+        for i in six.moves.range(3):  # pylint: disable=no-member
+            self.assertEqual(i, ExampleConfig.objects.all().count())
 
             request = self.factory.post('/config/ExampleConfig', {"string_field": str(i)})
             request.user = self.user
             response = self.current_view(request)
-            self.assertEquals(201, response.status_code)
+            self.assertEqual(201, response.status_code)
 
-            self.assertEquals(i + 1, ExampleConfig.objects.all().count())
-            self.assertEquals(str(i), ExampleConfig.current().string_field)
+            self.assertEqual(i + 1, ExampleConfig.objects.all().count())
+            self.assertEqual(str(i), ExampleConfig.current().string_field)
 
     def test_get_current(self):
         request = self.factory.get('/config/ExampleConfig')
         request.user = self.user
         response = self.current_view(request)
-        self.assertEquals('', response.data['string_field'])
-        self.assertEquals(10, response.data['int_field'])
-        self.assertEquals(None, response.data['changed_by'])
-        self.assertEquals(False, response.data['enabled'])
-        self.assertEquals(None, response.data['change_date'])
+        self.assertEqual('', response.data['string_field'])
+        self.assertEqual(10, response.data['int_field'])
+        self.assertEqual(None, response.data['changed_by'])
+        self.assertEqual(False, response.data['enabled'])
+        self.assertEqual(None, response.data['change_date'])
 
         ExampleConfig(string_field='string_value', int_field=20).save()
 
         response = self.current_view(request)
-        self.assertEquals('string_value', response.data['string_field'])
-        self.assertEquals(20, response.data['int_field'])
+        self.assertEqual('string_value', response.data['string_field'])
+        self.assertEqual(20, response.data['int_field'])
 
     @ddt.data(
         ('get', [], 200),
@@ -491,8 +498,8 @@ class ConfigurationModelAPITests(TestCase):
             password='no-perms',
         )
         response = self.current_view(request)
-        self.assertEquals(403, response.status_code)
+        self.assertEqual(403, response.status_code)
 
         request.user = self.user
         response = self.current_view(request)
-        self.assertEquals(status_code, response.status_code)
+        self.assertEqual(status_code, response.status_code)

--- a/config_models/tests/test_decorators.py
+++ b/config_models/tests/test_decorators.py
@@ -7,13 +7,16 @@ from __future__ import unicode_literals, absolute_import
 from config_models import decorators
 from config_models.models import ConfigurationModel
 from config_models.tests.utils import CacheIsolationTestCase
+from django.utils import six
 
 
+# pylint: disable=model-missing-unicode
+@six.python_2_unicode_compatible
 class ExampleDecoratorConfig(ConfigurationModel):
     """
     Test model for testing the require_config decorator
     """
-    def __unicode__(self):
+    def __str__(self):
         return "ExampleDecoratorConfig(enabled={})".format(self.enabled)
 
 

--- a/config_models/tests/test_model_deserialization.py
+++ b/config_models/tests/test_model_deserialization.py
@@ -5,10 +5,9 @@ from __future__ import unicode_literals, absolute_import
 
 import textwrap
 import os.path
+import io
 
-from django.utils import timezone
-from django.utils.six import BytesIO
-
+from django.utils import timezone, six
 from django.contrib.auth.models import User
 from django.core.management.base import CommandError
 from django.db import models
@@ -19,6 +18,8 @@ from config_models.utils import deserialize_json
 from config_models.tests.utils import CacheIsolationTestCase
 
 
+# pylint: disable=model-missing-unicode
+@six.python_2_unicode_compatible
 class ExampleDeserializeConfig(ConfigurationModel):
     """
     Test model for testing deserialization of ``ConfigurationModels`` with keyed configuration.
@@ -28,7 +29,7 @@ class ExampleDeserializeConfig(ConfigurationModel):
     name = models.TextField()
     int_field = models.IntegerField(default=10)
 
-    def __unicode__(self):
+    def __str__(self):
         return "ExampleDeserializeConfig(enabled={}, name={}, int_field={})".format(
             self.enabled, self.name, self.int_field
         )
@@ -50,23 +51,23 @@ class DeserializeJSONTests(CacheIsolationTestCase):
         A valid username is supplied for the operation.
         """
         start_date = timezone.now()
-        with open(self.fixture_path) as data:  # pylint: disable=open-builtin
+        with io.open(self.fixture_path, "rb") as data:
             entries_created = deserialize_json(data, self.test_username)
-            self.assertEquals(2, entries_created)
+            self.assertEqual(2, entries_created)
 
-        self.assertEquals(2, ExampleDeserializeConfig.objects.count())
+        self.assertEqual(2, ExampleDeserializeConfig.objects.count())
 
         betty = ExampleDeserializeConfig.current('betty')
         self.assertTrue(betty.enabled)
-        self.assertEquals(5, betty.int_field)
+        self.assertEqual(5, betty.int_field)
         self.assertGreater(betty.change_date, start_date)
-        self.assertEquals(self.test_username, betty.changed_by.username)
+        self.assertEqual(self.test_username, betty.changed_by.username)
 
         fred = ExampleDeserializeConfig.current('fred')
         self.assertFalse(fred.enabled)
-        self.assertEquals(10, fred.int_field)
+        self.assertEqual(10, fred.int_field)
         self.assertGreater(fred.change_date, start_date)
-        self.assertEquals(self.test_username, fred.changed_by.username)
+        self.assertEqual(self.test_username, fred.changed_by.username)
 
     def test_existing_entries_not_removed(self):
         """
@@ -76,15 +77,15 @@ class DeserializeJSONTests(CacheIsolationTestCase):
         ExampleDeserializeConfig(name="fred", enabled=True).save()
         ExampleDeserializeConfig(name="barney", int_field=200).save()
 
-        with open(self.fixture_path) as data:  # pylint: disable=open-builtin
+        with io.open(self.fixture_path, "rb") as data:
             entries_created = deserialize_json(data, self.test_username)
-            self.assertEquals(2, entries_created)
+            self.assertEqual(2, entries_created)
 
-        self.assertEquals(4, ExampleDeserializeConfig.objects.count())
-        self.assertEquals(3, len(ExampleDeserializeConfig.objects.current_set()))
+        self.assertEqual(4, ExampleDeserializeConfig.objects.count())
+        self.assertEqual(3, len(ExampleDeserializeConfig.objects.current_set()))
 
-        self.assertEquals(5, ExampleDeserializeConfig.current('betty').int_field)
-        self.assertEquals(200, ExampleDeserializeConfig.current('barney').int_field)
+        self.assertEqual(5, ExampleDeserializeConfig.current('betty').int_field)
+        self.assertEqual(200, ExampleDeserializeConfig.current('barney').int_field)
 
         # The JSON file changes "enabled" to False for Fred.
         fred = ExampleDeserializeConfig.current('fred')
@@ -95,32 +96,32 @@ class DeserializeJSONTests(CacheIsolationTestCase):
         If there is no change in an entry (besides changed_by and change_date),
         a new entry is not made.
         """
-        with open(self.fixture_path) as data:  # pylint: disable=open-builtin
+        with io.open(self.fixture_path, "rb") as data:
             entries_created = deserialize_json(data, self.test_username)
-            self.assertEquals(2, entries_created)
+            self.assertEqual(2, entries_created)
 
-        with open(self.fixture_path) as data:  # pylint: disable=open-builtin
+        with io.open(self.fixture_path, "rb") as data:
             entries_created = deserialize_json(data, self.test_username)
-            self.assertEquals(0, entries_created)
+            self.assertEqual(0, entries_created)
 
         # Importing twice will still only result in 2 records (second import a no-op).
-        self.assertEquals(2, ExampleDeserializeConfig.objects.count())
+        self.assertEqual(2, ExampleDeserializeConfig.objects.count())
 
         # Change Betty.
         betty = ExampleDeserializeConfig.current('betty')
         betty.int_field = -8
         betty.save()
 
-        self.assertEquals(3, ExampleDeserializeConfig.objects.count())
-        self.assertEquals(-8, ExampleDeserializeConfig.current('betty').int_field)
+        self.assertEqual(3, ExampleDeserializeConfig.objects.count())
+        self.assertEqual(-8, ExampleDeserializeConfig.current('betty').int_field)
 
         # Now importing will add a new entry for Betty.
-        with open(self.fixture_path) as data:  # pylint: disable=open-builtin
+        with io.open(self.fixture_path, "rb") as data:
             entries_created = deserialize_json(data, self.test_username)
-            self.assertEquals(1, entries_created)
+            self.assertEqual(1, entries_created)
 
-        self.assertEquals(4, ExampleDeserializeConfig.objects.count())
-        self.assertEquals(5, ExampleDeserializeConfig.current('betty').int_field)
+        self.assertEqual(4, ExampleDeserializeConfig.objects.count())
+        self.assertEqual(5, ExampleDeserializeConfig.current('betty').int_field)
 
     def test_bad_username(self):
         """
@@ -132,8 +133,10 @@ class DeserializeJSONTests(CacheIsolationTestCase):
                 "data": [{"name": "dino"}]
             }
             """)
-        with self.assertRaisesRegexp(Exception, "User matching query does not exist"):
-            deserialize_json(BytesIO(test_json), "unknown_username")
+        if six.PY3:
+            test_json = test_json.encode('utf-8')
+        with six.assertRaisesRegex(self, Exception, "User matching query does not exist"):
+            deserialize_json(six.BytesIO(test_json), "unknown_username")
 
     def test_invalid_json(self):
         """
@@ -144,8 +147,10 @@ class DeserializeJSONTests(CacheIsolationTestCase):
                 "model": "config_models.ExampleDeserializeConfig",
                 "data": [{"name": "dino"
             """)
-        with self.assertRaisesRegexp(Exception, "JSON parse error"):
-            deserialize_json(BytesIO(test_json), self.test_username)
+        if six.PY3:
+            test_json = test_json.encode('utf-8')
+        with six.assertRaisesRegex(self, Exception, "JSON parse error"):
+            deserialize_json(six.BytesIO(test_json), self.test_username)
 
     def test_invalid_model(self):
         """
@@ -157,8 +162,10 @@ class DeserializeJSONTests(CacheIsolationTestCase):
                 "data":[{"name": "dino"}]
             }
             """)
-        with self.assertRaisesRegexp(Exception, "No installed app"):
-            deserialize_json(BytesIO(test_json), self.test_username)
+        if six.PY3:
+            test_json = test_json.encode('utf-8')
+        with six.assertRaisesRegex(self, Exception, "No installed app"):
+            deserialize_json(six.BytesIO(test_json), self.test_username)
 
 
 class PopulateModelTestCase(CacheIsolationTestCase):
@@ -177,40 +184,40 @@ class PopulateModelTestCase(CacheIsolationTestCase):
         A valid username is supplied for the operation.
         """
         _run_command(file=self.file_path, username=self.test_username)
-        self.assertEquals(2, ExampleDeserializeConfig.objects.count())
+        self.assertEqual(2, ExampleDeserializeConfig.objects.count())
 
         betty = ExampleDeserializeConfig.current('betty')
-        self.assertEquals(self.test_username, betty.changed_by.username)
+        self.assertEqual(self.test_username, betty.changed_by.username)
 
         fred = ExampleDeserializeConfig.current('fred')
-        self.assertEquals(self.test_username, fred.changed_by.username)
+        self.assertEqual(self.test_username, fred.changed_by.username)
 
     def test_no_user_specified(self):
         """
         Tests that a username must be specified.
         """
-        with self.assertRaisesRegexp(CommandError, "A valid username must be specified"):
+        with six.assertRaisesRegex(self, CommandError, "A valid username must be specified"):
             _run_command(file=self.file_path)
 
     def test_bad_user_specified(self):
         """
         Tests that a username must be specified.
         """
-        with self.assertRaisesRegexp(Exception, "User matching query does not exist"):
+        with six.assertRaisesRegex(self, Exception, "User matching query does not exist"):
             _run_command(file=self.file_path, username="does_not_exist")
 
     def test_no_file_specified(self):
         """
         Tests the error handling when no JSON file is supplied.
         """
-        with self.assertRaisesRegexp(CommandError, "A file containing JSON must be specified"):
+        with six.assertRaisesRegex(self, CommandError, "A file containing JSON must be specified"):
             _run_command(username=self.test_username)
 
     def test_bad_file_specified(self):
         """
         Tests the error handling when the path to the JSON file is incorrect.
         """
-        with self.assertRaisesRegexp(CommandError, "File does/not/exist.json does not exist"):
+        with six.assertRaisesRegex(self, CommandError, "File does/not/exist.json does not exist"):
             _run_command(file="does/not/exist.json", username=self.test_username)
 
 

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -4,3 +4,4 @@ caniusepython3            # Additional Python 3 compatibility pylint checks
 edx-lint                  # edX pylint rules and plugins
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation
+futures==3.2.0 ; python_version == "2.7"  # via caniusepython3, isort

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,7 +16,7 @@ configparser==3.5.0       # via pydocstyle, pylint
 distlib==0.2.7            # via caniusepython3
 edx-lint==0.5.5
 enum34==1.1.6             # via astroid
-futures==3.2.0            # via caniusepython3, isort
+futures==3.2.0 ; python_version == "2.7"  # via caniusepython3, isort
 idna==2.6                 # via requests
 isort==4.3.4              # via pylint
 lazy-object-proxy==1.3.1  # via astroid

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,6 +1,6 @@
 # Requirements for test runs.
 
-
+futures ; python_version == "2.7"
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 ddt

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,7 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27}-django{18,19,110,111}
+envlist = {py27,py36}-django{18,19,110,111}
 
 [pep8]
 exclude = .git,.tox,migrations


### PR DESCRIPTION
**Background:** An effort is being made to move everything from Python 2.7 to 3, including making this repository compatible with both as specified on this JIRA issue: https://openedx.atlassian.net/projects/INCR/issues/INCR-18?filter=allopenissues and these changes aim to do that.

**Studio Updates:** None.

**LMS Updates:** None

Testing: Same ones as before (and have been updated to be compatible with both as well), passing.