### PR TITLE
Correct the TOXENV we release from.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ deploy:
   on:
     tags: true
     python: 3.6
-    condition: '$TOXENV = django111'
+    condition: '$TOXENV = quality'
   password:
     secure: Mk/97Np4pwZte72JOOiJtv/nKJR+JBvtOkEnvWcMWVhJ36n4/nVOlzX+/3kA8CjIHJQHF6LGbx+XPAcTxBqVzJW8EjN94kFitLsb6Xvl/ucADElGfXyN2wXZODtv8SFFY711MEmILqrd8E58JLhbzD+mcvngkS3DCT0msZB224zRn6w+6tmfatW6D4oFqisJnULUSRKRvZiRgrtyweMcXgLaEQAF4Lc4oO9/Nfq9pX3zqH/y5GyuRJlVQPGn32gvZtiiulMfJYQfCX/9/swPYe44Nv8jACaPgvILVGJ9UeltUIuif1HHw3S2isJq9ZFA8BAcTOsjdDRazem0QHxKdO5ZF3Eqtgcr4LA3QtGIcIuUP+prn4lg71HrPIs4TMQzDozpmwF0lr+IYYbeTO9QgBjcbrx7Nc5SMbr5wvSbd9EGOIlZ6shjS1H2Z78OYBiuRmZW5FuF2QDx1qa4kBdtQtewS+IMpUzhwXs6mN6Rbz+Mkm7xSjP8TeZSmcs20zBp3sLirZc0ypep8GaPjKwJrb7+vai40u4t2/rJQKsoDVUmL/FjLmwazQ3Dacgsr+44MZMlw7uLOynP72P24h6MGv6F9k2FcChVpQ9+DjldU7FDVUZLdgXn8oiO8HpfPAYKqjRLOy+q4ed2zqfBw4w5JCV9A02j50WNi0ZeEqpvnDk=


### PR DESCRIPTION
Use 'quality' which will always exists instead of dango111 which no
longer exists after we added the various DRF shards changing the value
of the TOXENV.