### PR TITLE
Bump pip-tools and run make upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 django==1.11.20
-djangorestframework==3.9.2
+djangorestframework==3.9.3
 pytz==2019.1              # via django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,15 +15,20 @@ chardet==3.0.4
 click-log==0.3.2
 click==7.0
 codecov==2.0.15
+configparser==3.7.4
+contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3
 ddt==1.2.1
 distlib==0.2.8
 django==1.11.20
-djangorestframework==3.9.2
+djangorestframework==3.9.3
 edx-i18n-tools==0.4.8
 edx-lint==1.1.2
+enum34==1.1.6
 filelock==3.0.10
 freezegun==0.3.11
+funcsigs==1.0.2
+futures==3.2.0 ; python_version == "2.7"
 idna==2.8
 importlib-metadata==0.9   # via path.py
 isort==4.3.17
@@ -32,9 +37,10 @@ mccabe==0.6.1
 mock==2.0.0
 more-itertools==5.0.0
 packaging==19.0
-path.py==12.0.1           # via edx-i18n-tools
-pbr==5.1.3
-pip-tools==3.6.0
+path.py==11.5.2           # via edx-i18n-tools
+pathlib2==2.3.3
+pbr==5.2.0
+pip-tools==3.6.1
 pluggy==0.9.0
 polib==1.1.0              # via edx-i18n-tools
 py==1.8.0
@@ -52,12 +58,14 @@ python-dateutil==2.8.0
 pytz==2019.1
 pyyaml==5.1               # via edx-i18n-tools
 requests==2.21.0
+scandir==1.10.0
+singledispatch==3.4.0.3
 six==1.12.0
 snowballstemmer==1.2.1
 toml==0.10.0
 tox-battery==0.5.1
 tox==3.9.0
 urllib3==1.24.2
-virtualenv==16.4.3
+virtualenv==16.5.0
 wrapt==1.11.1
-zipp==0.3.3               # via importlib-metadata
+zipp==0.4.0               # via importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,42 +4,31 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12         # via sphinx
 atomicwrites==1.3.0
 attrs==19.1.0
-babel==2.6.0              # via sphinx
 bleach==3.1.0             # via readme-renderer
-certifi==2019.3.9         # via requests
-chardet==3.0.4            # via requests
 coverage==4.5.3
 ddt==1.2.1
 django==1.11.20
-djangorestframework==3.9.2
-docutils==0.14            # via readme-renderer, sphinx
+djangorestframework==3.9.3
+docutils==0.14            # via readme-renderer
 freezegun==0.3.11
-idna==2.8                 # via requests
-imagesize==1.1.0          # via sphinx
-jinja2==2.10.1            # via sphinx
-markupsafe==1.1.1         # via jinja2
+funcsigs==1.0.2
 mock==2.0.0
 more-itertools==5.0.0
-packaging==19.0           # via sphinx
-pbr==5.1.3
+pathlib2==2.3.3
+pbr==5.2.0
 pluggy==0.9.0
 py==1.8.0
-pygments==2.3.1           # via readme-renderer, sphinx
-pyparsing==2.4.0          # via packaging
+pygments==2.3.1           # via readme-renderer
 pytest-cov==2.6.1
 pytest-django==3.4.8
 pytest==4.4.1
 python-dateutil==2.8.0
 pytz==2019.1
 readme-renderer==24.0
-requests==2.21.0          # via sphinx
+scandir==1.10.0
 six==1.12.0
-snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
-sphinxcontrib-websupport==1.1.0  # via sphinx
-urllib3==1.24.2           # via requests
 webencodings==0.5.1       # via bleach

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==3.6.0
+pip-tools==3.6.1
 six==1.12.0               # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,19 +8,23 @@ argparse==1.4.0           # via caniusepython3
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0
 attrs==19.1.0
-backports.functools-lru-cache==1.5  # via caniusepython3
+backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
 caniusepython3==7.0.0
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
+configparser==3.7.4       # via pydocstyle, pylint
 coverage==4.5.3
 ddt==1.2.1
 distlib==0.2.8            # via caniusepython3
 django==1.11.20
-djangorestframework==3.9.2
+djangorestframework==3.9.3
 edx-lint==1.1.2
+enum34==1.1.6             # via astroid
 freezegun==0.3.11
+funcsigs==1.0.2
+futures==3.2.0 ; python_version == "2.7"
 idna==2.8                 # via requests
 isort==4.3.17             # via pylint
 lazy-object-proxy==1.3.1  # via astroid
@@ -28,7 +32,8 @@ mccabe==0.6.1             # via pylint
 mock==2.0.0
 more-itertools==5.0.0
 packaging==19.0           # via caniusepython3
-pbr==5.1.3
+pathlib2==2.3.3
+pbr==5.2.0
 pluggy==0.9.0
 py==1.8.0
 pycodestyle==2.5.0
@@ -44,6 +49,8 @@ pytest==4.4.1
 python-dateutil==2.8.0
 pytz==2019.1
 requests==2.21.0          # via caniusepython3
+scandir==1.10.0
+singledispatch==3.4.0.3   # via astroid, pylint
 six==1.12.0
 snowballstemmer==1.2.1    # via pydocstyle
 urllib3==1.24.2           # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,9 +9,11 @@ attrs==19.1.0             # via pytest
 coverage==4.5.3           # via pytest-cov
 ddt==1.2.1
 freezegun==0.3.11
+funcsigs==1.0.2           # via mock, pytest
 mock==2.0.0
 more-itertools==5.0.0     # via pytest
-pbr==5.1.3                # via mock
+pathlib2==2.3.3           # via pytest, pytest-django
+pbr==5.2.0                # via mock
 pluggy==0.9.0             # via pytest
 py==1.8.0                 # via pytest
 pytest-cov==2.6.1
@@ -19,4 +21,5 @@ pytest-django==3.4.8
 pytest==4.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.0    # via freezegun
 pytz==2019.1
-six==1.12.0               # via freezegun, mock, more-itertools, pytest, python-dateutil
+scandir==1.10.0           # via pathlib2
+six==1.12.0               # via freezegun, mock, pathlib2, pytest, python-dateutil

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -18,4 +18,4 @@ toml==0.10.0              # via tox
 tox-battery==0.5.1
 tox==3.9.0
 urllib3==1.24.2           # via requests
-virtualenv==16.4.3        # via tox
+virtualenv==16.5.0        # via tox


### PR DESCRIPTION
Similar to this PR: https://github.com/edx/devstack/pull/401 , a manual upgrade of `pip-tools` to `3.6.1` was required to fix the auto dependency PRs