### PR TITLE
Add Request level caching, bump to version 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
 env:
@@ -14,29 +13,10 @@ env:
 - TOXENV=django22-drflatest
 
 matrix:
-  exclude:
-    - python: 2.7
-      env: TOXENV=django20-drf39
-    - python: 2.7
-      env: TOXENV=django20-drflatest
-    - python: 2.7
-      env: TOXENV=django21-drf39
-    - python: 2.7
-      env: TOXENV=django21-drflatest
-    - python: 2.7
-      env: TOXENV=django22-drf39
-    - python: 2.7
-      env: TOXENV=django22-drflatest
-
-
   include:
   - python: 3.5
     env: TOXENV=quality
   - python: 3.5
-    env: TOXENV=docs
-  - python: 2.7
-    env: TOXENV=quality
-  - python: 2.7
     env: TOXENV=docs
 cache:
 - pip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ Change Log
 ----------
 
 ..
-   All enhancements and patches to cookiecutter-django-app will be documented
+   All enhancements and patches to django-config-models will be documented
    in this file.  It adheres to the structure of http://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
@@ -13,6 +13,19 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[2.0.0] - 2020-01-08
+~~~~~~~~~~~~~~~~~~~~
+* Switch to using edx-django-utils TieredCache (a two-layer cache that uses both
+  Django's cache and an internal request-level cache) to reduce the number of
+  memcached roundtrips. This was a major performance issue that accounted for
+  10-20% of transaction time for certain courseware views in edx-platform.
+* It is now REQUIRED to [add `RequestCacheMiddleware` to middleware](https://github.com/edx/edx-django-utils/tree/master/edx_django_utils/cache#tieredcachemiddleware).
+  to use ConfigModels.
+* Remove usage of the "configuration" cache setting. ConfigModels now always use
+  the default Django cache.
+* Django Rest Framework 3.7 and 3.8 are no longer supported.
+
 [1.0.1] - 2019-04-23
 ~~~~~~~~~~~~~~~~~~~~
 * Fix auto publishing to PyPI

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,8 @@ Unreleased
   Django's cache and an internal request-level cache) to reduce the number of
   memcached roundtrips. This was a major performance issue that accounted for
   10-20% of transaction time for certain courseware views in edx-platform.
-* It is now REQUIRED to [add `RequestCacheMiddleware` to middleware](https://github.com/edx/edx-django-utils/tree/master/edx_django_utils/cache#tieredcachemiddleware).
+* It is now REQUIRED to add `RequestCacheMiddleware` `to middleware
+  <https://github.com/edx/edx-django-utils/tree/master/edx_django_utils/cache#tieredcachemiddleware>`_
   to use ConfigModels.
 * Remove usage of the "configuration" cache setting. ConfigModels now always use
   the default Django cache.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-[2.0.0] - 2020-01-08
+[2.0.0] - 2020-02-06
 ~~~~~~~~~~~~~~~~~~~~
 * Switch to using edx-django-utils TieredCache (a two-layer cache that uses both
   Django's cache and an internal request-level cache) to reduce the number of

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Unreleased
 
 [2.0.0] - 2020-02-06
 ~~~~~~~~~~~~~~~~~~~~
+* Dropping support for Python 2.7
 * Switch to using edx-django-utils TieredCache (a two-layer cache that uses both
   Django's cache and an internal request-level cache) to reduce the number of
   memcached roundtrips. This was a major performance issue that accounted for

--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,13 @@ fake_translations: extract_translations dummy_translations compile_translations 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -r requirements/pip-tools.txt
-	pip-compile --rebuild --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
-	pip-compile --rebuild --upgrade -o requirements/base.txt requirements/base.in
-	pip-compile --rebuild --upgrade -o requirements/test.txt requirements/test.in
-	pip-compile --rebuild --upgrade -o requirements/doc.txt requirements/doc.in
-	pip-compile --rebuild --upgrade -o requirements/quality.txt requirements/quality.in
-	pip-compile --rebuild --upgrade -o requirements/travis.txt requirements/travis.in
-	pip-compile --rebuild --upgrade -o requirements/dev.txt requirements/dev.in
+	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/base.txt requirements/base.in
+	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/test.txt requirements/test.in
+	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/doc.txt requirements/doc.in
+	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/quality.txt requirements/quality.in
+	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/travis.txt requirements/travis.in
+	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django and djangorestframework versions for tests
 	sed -i.tmp '/^[d|D]jango==/d' requirements/test.txt
 	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt

--- a/config_models/__init__.py
+++ b/config_models/__init__.py
@@ -4,6 +4,6 @@ Configuration models for Django allowing config management with auditing.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.4'
+__version__ = '2.0.0'
 
 default_app_config = 'config_models.apps.ConfigModelsConfig'  # pylint: disable=invalid-name

--- a/config_models/models.py
+++ b/config_models/models.py
@@ -74,7 +74,7 @@ class ConfigurationModel(models.Model):
             should be cached
     """
 
-    class Meta(object):
+    class Meta:
         abstract = True
         ordering = ("-change_date", )
 
@@ -139,7 +139,7 @@ class ConfigurationModel(models.Model):
 
         key_dict = dict(zip(cls.KEY_FIELDS, args))
         try:
-            current = cls.objects.filter(**key_dict).order_by('-change_date')[0]  # pylint: disable=no-member
+            current = cls.objects.filter(**key_dict).order_by('-change_date')[0]
         except IndexError:
             current = cls(**key_dict)
 

--- a/config_models/models.py
+++ b/config_models/models.py
@@ -13,7 +13,7 @@ from rest_framework.utils import model_meta
 
 # The following import exists for backwards compatibility (because a number of
 # library users assume config_models.models.cache is importable), but
-# ConfigModels will now ignore the cutom 'configuration' cache setting and just
+# ConfigModels will now ignore the custom 'configuration' cache setting and just
 # use TieredCache, which will make use of a local request cache + the default
 # Django cache.
 from django.core.cache import cache  # pylint: disable=unused-import

--- a/config_models/utils.py
+++ b/config_models/utils.py
@@ -14,7 +14,7 @@ def get_serializer_class(configuration_model):
     class AutoConfigModelSerializer(ModelSerializer):
         """Serializer class for configuration models."""
 
-        class Meta(object):
+        class Meta:
             """Meta information for AutoConfigModelSerializer."""
             model = configuration_model
             fields = '__all__'

--- a/config_models/views.py
+++ b/config_models/views.py
@@ -17,7 +17,7 @@ class ReadableOnlyByAuthors(DjangoModelPermissions):
     perms_map['GET'] = perms_map['OPTIONS'] = perms_map['HEAD'] = perms_map['POST']
 
 
-class AtomicMixin(object):
+class AtomicMixin:
     """Mixin to provide atomic transaction for as_view."""
     @classmethod
     def create_atomic_wrapper(cls, wrapped_func):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,4 +3,3 @@
 
 Django>=1.8,<3                       # Web application framework
 djangorestframework>=3.6
-edx-django-utils<3

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,3 +3,4 @@
 
 Django>=1.8,<3                       # Web application framework
 djangorestframework>=3.6
+edx-django-utils<3

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,3 +3,4 @@
 
 Django>=1.8,<3                       # Web application framework
 djangorestframework>=3.6
+edx-django-utils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,15 +4,7 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
-
-django-waffle==0.18.0     # via edx-django-utils
-django==2.2.9
+django==2.2.10
 djangorestframework==3.11.0
-edx-django-utils==2.0.2
-newrelic==5.4.1.134       # via edx-django-utils
-psutil==1.2.1             # via edx-django-utils
 pytz==2019.3              # via django
 sqlparse==0.3.0           # via django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,15 @@
 #
 #    make upgrade
 #
-django==1.11.27
-djangorestframework==3.9.4
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
+django-waffle==0.18.0     # via edx-django-utils
+django==2.2.9
+djangorestframework==3.11.0
+edx-django-utils==2.0.2
+newrelic==5.4.1.134       # via edx-django-utils
+psutil==1.2.1             # via edx-django-utils
 pytz==2019.3              # via django
+sqlparse==0.3.0           # via django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,12 @@
 #
 #    make upgrade
 #
+django-waffle==0.19.0     # via edx-django-utils
 django==2.2.10
 djangorestframework==3.11.0
+edx-django-utils==2.0.4
+newrelic==5.6.0.135       # via edx-django-utils
+psutil==1.2.1             # via edx-django-utils
 pytz==2019.3              # via django
+six==1.14.0               # via django-waffle
 sqlparse==0.3.0           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,3 +15,14 @@ Sphinx<2.0.0
 # A dependency of pytest.  Pytest doesn't constrain it and 6.0.0 onward
 # only works with python 3
 more-itertools<6.0.0
+
+# We now use TieredCache from edx-django-utils. Putting this constaint just
+# so that we don't get bitten by any backwards-incompatible changes that may
+# happen in v3 of that library.
+edx-django-utils<3
+
+# The following packages are pinned because more recent versions require
+# Python 3.6+
+twine<2.0
+mock<4.0
+zipp<2.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -24,5 +24,4 @@ edx-django-utils<3
 # The following packages are pinned because more recent versions require
 # Python 3.6+
 twine<2.0
-mock<4.0
 zipp<2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,8 +17,10 @@ codecov==2.0.15
 coverage==5.0.3
 ddt==1.2.2
 distlib==0.3.0
+django-waffle==0.19.0
 django==2.2.10
 djangorestframework==3.11.0
+edx-django-utils==2.0.4
 edx-i18n-tools==0.5.0
 edx-lint==1.4.1
 filelock==3.0.12
@@ -30,6 +32,7 @@ lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mock==3.0.5
 more-itertools==5.0.0
+newrelic==5.6.0.135
 packaging==20.1
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
@@ -37,6 +40,7 @@ pathlib2==2.3.5
 pip-tools==4.4.1
 pluggy==0.13.1
 polib==1.1.0              # via edx-i18n-tools
+psutil==1.2.1
 py==1.8.1
 pycodestyle==2.5.0
 pydocstyle==5.0.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
-
 argparse==1.4.0
 astroid==2.3.3
 attrs==19.3.0
@@ -18,61 +14,57 @@ chardet==3.0.4
 click-log==0.3.2
 click==7.0
 codecov==2.0.15
-coverage==5.0.2
+coverage==5.0.3
 ddt==1.2.2
 distlib==0.3.0
-django-waffle==0.18.0
-django==2.2.9
+django==2.2.10
 djangorestframework==3.11.0
-edx-django-utils==2.0.2
 edx-i18n-tools==0.5.0
 edx-lint==1.4.1
 filelock==3.0.12
-freezegun==0.3.12
+freezegun==0.3.14
 idna==2.8
-importlib-metadata==1.3.0
+importlib-metadata==1.5.0
 isort==4.3.21
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mock==3.0.5
 more-itertools==5.0.0
-newrelic==5.4.1.134
-packaging==20.0
+packaging==20.1
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5
-pip-tools==4.3.0
+pip-tools==4.4.1
 pluggy==0.13.1
 polib==1.1.0              # via edx-i18n-tools
-psutil==1.2.1
 py==1.8.1
 pycodestyle==2.5.0
-pydocstyle==5.0.1
+pydocstyle==5.0.2
 pylint-celery==0.3
 pylint-django==2.0.11
 pylint-plugin-utils==0.6
 pylint==2.4.2
 pyparsing==2.4.6
 pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest==5.3.2
+pytest-django==3.8.0
+pytest==5.3.5
 python-dateutil==2.8.1
 pytz==2019.3
 pyyaml==5.3               # via edx-i18n-tools
 requests==2.22.0
-six==1.13.0
+six==1.14.0
 snowballstemmer==2.0.0
 sqlparse==0.3.0
 toml==0.10.0
-tox-battery==0.5.1
+tox-battery==0.5.2
 tox-travis==0.12
 tox==3.14.3
-typed-ast==1.4.0
-urllib3==1.25.7
+typed-ast==1.4.1
+urllib3==1.25.8
 virtualenv==16.7.9
 wcwidth==0.1.8
 wrapt==1.11.2
-zipp==0.6.0
+zipp==1.1.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,9 +4,12 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 argparse==1.4.0
-astroid==1.6.6
-atomicwrites==1.3.0
+astroid==2.3.3
 attrs==19.3.0
 backports.functools-lru-cache==1.6.1
 caniusepython3==7.2.0
@@ -15,20 +18,17 @@ chardet==3.0.4
 click-log==0.3.2
 click==7.0
 codecov==2.0.15
-configparser==4.0.2
-contextlib2==0.6.0.post1
 coverage==5.0.2
 ddt==1.2.2
 distlib==0.3.0
-django==1.11.27
-djangorestframework==3.9.4
+django-waffle==0.18.0
+django==2.2.9
+djangorestframework==3.11.0
+edx-django-utils==2.0.2
 edx-i18n-tools==0.5.0
 edx-lint==1.4.1
-enum34==1.1.6
 filelock==3.0.12
 freezegun==0.3.12
-funcsigs==1.0.2
-futures==3.2.0 ; python_version == "2.7"
 idna==2.8
 importlib-metadata==1.3.0
 isort==4.3.21
@@ -36,35 +36,38 @@ lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mock==3.0.5
 more-itertools==5.0.0
+newrelic==5.4.1.134
 packaging==20.0
-path.py==11.5.2           # via edx-i18n-tools
+path.py==12.4.0           # via edx-i18n-tools
+path==13.1.0              # via path.py
 pathlib2==2.3.5
 pip-tools==4.3.0
 pluggy==0.13.1
 polib==1.1.0              # via edx-i18n-tools
+psutil==1.2.1
 py==1.8.1
 pycodestyle==2.5.0
-pydocstyle==3.0.0
+pydocstyle==5.0.1
 pylint-celery==0.3
-pylint-django==0.11.1
+pylint-django==2.0.11
 pylint-plugin-utils==0.6
-pylint==1.9.5
+pylint==2.4.2
 pyparsing==2.4.6
 pytest-cov==2.8.1
 pytest-django==3.7.0
-pytest==4.6.9
+pytest==5.3.2
 python-dateutil==2.8.1
 pytz==2019.3
 pyyaml==5.3               # via edx-i18n-tools
 requests==2.22.0
-scandir==1.10.0
-singledispatch==3.4.0.3
 six==1.13.0
 snowballstemmer==2.0.0
+sqlparse==0.3.0
 toml==0.10.0
 tox-battery==0.5.1
 tox-travis==0.12
 tox==3.14.3
+typed-ast==1.4.0
 urllib3==1.25.7
 virtualenv==16.7.9
 wcwidth==0.1.8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,7 +30,6 @@ importlib-metadata==1.5.0
 isort==4.3.21
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
-mock==3.0.5
 more-itertools==5.0.0
 newrelic==5.6.0.135
 packaging==20.1

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -6,4 +6,4 @@
 readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder
 sphinx_rtd_theme          # ReadTheDocs theme for Sphinx output
-twine
+twine<2.0                 # 2.0 and above requires Python 3.6+

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -6,4 +6,3 @@
 readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder
 sphinx_rtd_theme          # ReadTheDocs theme for Sphinx output
-twine<2.0                 # 2.0 and above requires Python 3.6+

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -6,3 +6,4 @@
 readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder
 sphinx_rtd_theme          # ReadTheDocs theme for Sphinx output
+twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -23,7 +23,6 @@ imagesize==1.2.0          # via sphinx
 importlib-metadata==1.5.0
 jinja2==2.11.1            # via sphinx
 markupsafe==1.1.1         # via jinja2
-mock==3.0.5
 more-itertools==5.0.0
 newrelic==5.6.0.135
 packaging==20.1
@@ -46,7 +45,7 @@ six==1.14.0
 snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
-sphinxcontrib-websupport==1.1.2  # via sphinx
+sphinxcontrib-websupport==1.2.0  # via sphinx
 sqlparse==0.3.0
 tqdm==4.42.1              # via twine
 twine==1.15.0

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,9 +12,11 @@ certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 coverage==5.0.3
 ddt==1.2.2
+django-waffle==0.19.0
 django==2.2.10
 djangorestframework==3.11.0
 docutils==0.16            # via readme-renderer, sphinx
+edx-django-utils==2.0.4
 freezegun==0.3.14
 idna==2.8                 # via requests
 imagesize==1.2.0          # via sphinx
@@ -23,9 +25,12 @@ jinja2==2.11.1            # via sphinx
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5
 more-itertools==5.0.0
+newrelic==5.6.0.135
 packaging==20.1
 pathlib2==2.3.5
+pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1
+psutil==1.2.1
 py==1.8.1
 pygments==2.5.2           # via readme-renderer, sphinx
 pyparsing==2.4.6
@@ -35,13 +40,16 @@ pytest==5.3.5
 python-dateutil==2.8.1
 pytz==2019.3
 readme-renderer==24.0
-requests==2.22.0          # via sphinx
+requests-toolbelt==0.9.1  # via twine
+requests==2.22.0          # via requests-toolbelt, sphinx, twine
 six==1.14.0
 snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2  # via sphinx
 sqlparse==0.3.0
+tqdm==4.42.1              # via twine
+twine==1.15.0
 urllib3==1.25.8           # via requests
 wcwidth==0.1.8
 webencodings==0.5.1       # via bleach

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,22 +4,24 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 alabaster==0.7.12         # via sphinx
-atomicwrites==1.3.0
 attrs==19.3.0
 babel==2.8.0              # via sphinx
 bleach==3.1.0             # via readme-renderer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-configparser==4.0.2
-contextlib2==0.6.0.post1
 coverage==5.0.2
 ddt==1.2.2
-django==1.11.27
-djangorestframework==3.9.4
+django-waffle==0.18.0
+django==2.2.9
+djangorestframework==3.11.0
 docutils==0.15.2          # via readme-renderer, sphinx
+edx-django-utils==2.0.2
 freezegun==0.3.12
-funcsigs==1.0.2
 idna==2.8                 # via requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.3.0
@@ -27,30 +29,31 @@ jinja2==2.10.3            # via sphinx
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5
 more-itertools==5.0.0
+newrelic==5.4.1.134
 packaging==20.0
 pathlib2==2.3.5
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1
+psutil==1.2.1
 py==1.8.1
 pygments==2.5.2           # via readme-renderer, sphinx
 pyparsing==2.4.6
 pytest-cov==2.8.1
 pytest-django==3.7.0
-pytest==4.6.9
+pytest==5.3.2
 python-dateutil==2.8.1
 pytz==2019.3
 readme-renderer==24.0
 requests-toolbelt==0.9.1  # via twine
 requests==2.22.0          # via requests-toolbelt, sphinx, twine
-scandir==1.10.0
 six==1.13.0
 snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2  # via sphinx
+sqlparse==0.3.0
 tqdm==4.41.1              # via twine
 twine==1.15.0
-typing==3.7.4.1           # via sphinx
 urllib3==1.25.7           # via requests
 wcwidth==0.1.8
 webencodings==0.5.1       # via bleach

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,60 +4,48 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
-
 alabaster==0.7.12         # via sphinx
 attrs==19.3.0
 babel==2.8.0              # via sphinx
 bleach==3.1.0             # via readme-renderer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-coverage==5.0.2
+coverage==5.0.3
 ddt==1.2.2
-django-waffle==0.18.0
-django==2.2.9
+django==2.2.10
 djangorestframework==3.11.0
-docutils==0.15.2          # via readme-renderer, sphinx
-edx-django-utils==2.0.2
-freezegun==0.3.12
+docutils==0.16            # via readme-renderer, sphinx
+freezegun==0.3.14
 idna==2.8                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.3.0
-jinja2==2.10.3            # via sphinx
+importlib-metadata==1.5.0
+jinja2==2.11.1            # via sphinx
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5
 more-itertools==5.0.0
-newrelic==5.4.1.134
-packaging==20.0
+packaging==20.1
 pathlib2==2.3.5
-pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1
-psutil==1.2.1
 py==1.8.1
 pygments==2.5.2           # via readme-renderer, sphinx
 pyparsing==2.4.6
 pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest==5.3.2
+pytest-django==3.8.0
+pytest==5.3.5
 python-dateutil==2.8.1
 pytz==2019.3
 readme-renderer==24.0
-requests-toolbelt==0.9.1  # via twine
-requests==2.22.0          # via requests-toolbelt, sphinx, twine
-six==1.13.0
+requests==2.22.0          # via sphinx
+six==1.14.0
 snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2  # via sphinx
 sqlparse==0.3.0
-tqdm==4.41.1              # via twine
-twine==1.15.0
-urllib3==1.25.7           # via requests
+urllib3==1.25.8           # via requests
 wcwidth==0.1.8
 webencodings==0.5.1       # via bleach
-zipp==0.6.0
+zipp==1.1.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 click==7.0                # via pip-tools
 pip-tools==4.3.0
 six==1.13.0               # via pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
-
 click==7.0                # via pip-tools
-pip-tools==4.3.0
-six==1.13.0               # via pip-tools
+pip-tools==4.4.1
+six==1.14.0               # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,8 +16,10 @@ click==7.0                # via click-log, edx-lint
 coverage==5.0.3
 ddt==1.2.2
 distlib==0.3.0            # via caniusepython3
+django-waffle==0.19.0
 django==2.2.10
 djangorestframework==3.11.0
+edx-django-utils==2.0.4
 edx-lint==1.4.1
 freezegun==0.3.14
 idna==2.8                 # via requests
@@ -27,9 +29,11 @@ lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0
+newrelic==5.6.0.135
 packaging==20.1
 pathlib2==2.3.5
 pluggy==0.13.1
+psutil==1.2.1
 py==1.8.1
 pycodestyle==2.5.0
 pydocstyle==5.0.2

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,28 +4,28 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 argparse==1.4.0           # via caniusepython3
-astroid==1.6.6            # via pylint, pylint-celery
-atomicwrites==1.3.0
+astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0
-backports.functools-lru-cache==1.6.1  # via astroid, caniusepython3, isort, pylint
+backports.functools-lru-cache==1.6.1  # via caniusepython3
 caniusepython3==7.2.0
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
-configparser==4.0.2
-contextlib2==0.6.0.post1
 coverage==5.0.2
 ddt==1.2.2
 distlib==0.3.0            # via caniusepython3
-django==1.11.27
-djangorestframework==3.9.4
+django-waffle==0.18.0
+django==2.2.9
+djangorestframework==3.11.0
+edx-django-utils==2.0.2
 edx-lint==1.4.1
-enum34==1.1.6             # via astroid
 freezegun==0.3.12
-funcsigs==1.0.2
-futures==3.2.0 ; python_version == "2.7"
 idna==2.8                 # via requests
 importlib-metadata==1.3.0
 isort==4.3.21             # via pylint
@@ -33,27 +33,29 @@ lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0
+newrelic==5.4.1.134
 packaging==20.0
 pathlib2==2.3.5
 pluggy==0.13.1
+psutil==1.2.1
 py==1.8.1
 pycodestyle==2.5.0
-pydocstyle==3.0.0
+pydocstyle==5.0.1
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.11.1     # via edx-lint
+pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.6
 pytest-cov==2.8.1
 pytest-django==3.7.0
-pytest==4.6.9
+pytest==5.3.2
 python-dateutil==2.8.1
 pytz==2019.3
 requests==2.22.0          # via caniusepython3
-scandir==1.10.0
-singledispatch==3.4.0.3   # via astroid, pylint
 six==1.13.0
 snowballstemmer==2.0.0    # via pydocstyle
+sqlparse==0.3.0
+typed-ast==1.4.0          # via astroid
 urllib3==1.25.7           # via requests
 wcwidth==0.1.8
 wrapt==1.11.2             # via astroid

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -27,7 +27,6 @@ importlib-metadata==1.5.0
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
-mock==3.0.5
 more-itertools==5.0.0
 newrelic==5.6.0.135
 packaging==20.1

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
-
 argparse==1.4.0           # via caniusepython3
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0
@@ -17,49 +13,45 @@ certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
-coverage==5.0.2
+coverage==5.0.3
 ddt==1.2.2
 distlib==0.3.0            # via caniusepython3
-django-waffle==0.18.0
-django==2.2.9
+django==2.2.10
 djangorestframework==3.11.0
-edx-django-utils==2.0.2
 edx-lint==1.4.1
-freezegun==0.3.12
+freezegun==0.3.14
 idna==2.8                 # via requests
-importlib-metadata==1.3.0
+importlib-metadata==1.5.0
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0
-newrelic==5.4.1.134
-packaging==20.0
+packaging==20.1
 pathlib2==2.3.5
 pluggy==0.13.1
-psutil==1.2.1
 py==1.8.1
 pycodestyle==2.5.0
-pydocstyle==5.0.1
+pydocstyle==5.0.2
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.6
 pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest==5.3.2
+pytest-django==3.8.0
+pytest==5.3.5
 python-dateutil==2.8.1
 pytz==2019.3
 requests==2.22.0          # via caniusepython3
-six==1.13.0
+six==1.14.0
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.0
-typed-ast==1.4.0          # via astroid
-urllib3==1.25.7           # via requests
+typed-ast==1.4.1          # via astroid
+urllib3==1.25.8           # via requests
 wcwidth==0.1.8
 wrapt==1.11.2             # via astroid
-zipp==0.6.0
+zipp==1.1.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -7,4 +7,3 @@ pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 ddt                       # Run a test case multiple times with different input
 freezegun                 # Allows tests to mock the output of assorted datetime module functions
-mock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,13 +7,17 @@
 attrs==19.3.0             # via pytest
 coverage==5.0.3           # via pytest-cov
 ddt==1.2.2
+django-waffle==0.19.0
+edx-django-utils==2.0.4
 freezegun==0.3.14
 importlib-metadata==1.5.0  # via pluggy, pytest
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
+newrelic==5.6.0.135
 packaging==20.1           # via pytest
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
+psutil==1.2.1
 py==1.8.1                 # via pytest
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1
@@ -21,7 +25,7 @@ pytest-django==3.8.0
 pytest==5.3.5             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via freezegun
 pytz==2019.3
-six==1.14.0               # via freezegun, mock, more-itertools, packaging, pathlib2, python-dateutil
+six==1.14.0
 sqlparse==0.3.0
 wcwidth==0.1.8            # via pytest
 zipp==1.1.0               # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,32 +4,24 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
-
 attrs==19.3.0             # via pytest
-coverage==5.0.2           # via pytest-cov
+coverage==5.0.3           # via pytest-cov
 ddt==1.2.2
-django-waffle==0.18.0
-edx-django-utils==2.0.2
-freezegun==0.3.12
-importlib-metadata==1.3.0  # via pluggy, pytest
+freezegun==0.3.14
+importlib-metadata==1.5.0  # via pluggy, pytest
 mock==3.0.5
-more-itertools==5.0.0     # via pytest, zipp
-newrelic==5.4.1.134
-packaging==20.0           # via pytest
+more-itertools==5.0.0     # via pytest
+packaging==20.1           # via pytest
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
-psutil==1.2.1
 py==1.8.1                 # via pytest
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest==5.3.2             # via pytest-cov, pytest-django
+pytest-django==3.8.0
+pytest==5.3.5             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via freezegun
 pytz==2019.3
-six==1.13.0               # via freezegun, mock, packaging, pathlib2, python-dateutil
+six==1.14.0               # via freezegun, mock, more-itertools, packaging, pathlib2, python-dateutil
 sqlparse==0.3.0
 wcwidth==0.1.8            # via pytest
-zipp==0.6.0               # via importlib-metadata
+zipp==1.1.0               # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,28 +4,32 @@
 #
 #    make upgrade
 #
-atomicwrites==1.3.0       # via pytest
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 attrs==19.3.0             # via pytest
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata
 coverage==5.0.2           # via pytest-cov
 ddt==1.2.2
+django-waffle==0.18.0
+edx-django-utils==2.0.2
 freezegun==0.3.12
-funcsigs==1.0.2           # via mock, pytest
 importlib-metadata==1.3.0  # via pluggy, pytest
 mock==3.0.5
 more-itertools==5.0.0     # via pytest, zipp
+newrelic==5.4.1.134
 packaging==20.0           # via pytest
-pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
+pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
+psutil==1.2.1
 py==1.8.1                 # via pytest
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1
 pytest-django==3.7.0
-pytest==4.6.9             # via pytest-cov, pytest-django
+pytest==5.3.2             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via freezegun
 pytz==2019.3
-scandir==1.10.0           # via pathlib2
-six==1.13.0               # via freezegun, mock, packaging, pathlib2, pytest, python-dateutil
+six==1.13.0               # via freezegun, mock, packaging, pathlib2, python-dateutil
+sqlparse==0.3.0
 wcwidth==0.1.8            # via pytest
 zipp==0.6.0               # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,6 @@ django-waffle==0.19.0
 edx-django-utils==2.0.4
 freezegun==0.3.14
 importlib-metadata==1.5.0  # via pluggy, pytest
-mock==3.0.5
 more-itertools==5.0.0     # via pytest
 newrelic==5.6.0.135
 packaging==20.1           # via pytest

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,28 +4,23 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
-
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
-coverage==5.0.2           # via codecov
+coverage==5.0.3           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-importlib-metadata==1.3.0  # via pluggy, tox
-more-itertools==5.0.0     # via zipp
-packaging==20.0           # via tox
+importlib-metadata==1.5.0  # via pluggy, tox
+packaging==20.1           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.6          # via packaging
 requests==2.22.0          # via codecov
-six==1.13.0               # via packaging, tox
+six==1.14.0               # via packaging, tox
 toml==0.10.0              # via tox
-tox-battery==0.5.1
+tox-battery==0.5.2
 tox-travis==0.12
 tox==3.14.3
-urllib3==1.25.7           # via requests
+urllib3==1.25.8           # via requests
 virtualenv==16.7.9        # via tox
-zipp==0.6.0               # via importlib-metadata
+zipp==1.1.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,24 +4,24 @@
 #
 #    make upgrade
 #
+--index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
+--extra-index-url https://pypi.python.org/simple
+--trusted-host edx.devstack.devpi
+
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata
 coverage==5.0.2           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
 importlib-metadata==1.3.0  # via pluggy, tox
 more-itertools==5.0.0     # via zipp
 packaging==20.0           # via tox
-pathlib2==2.3.5           # via importlib-metadata
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.6          # via packaging
 requests==2.22.0          # via codecov
-scandir==1.10.0           # via pathlib2
-six==1.13.0               # via packaging, pathlib2, tox
+six==1.13.0               # via packaging, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
 tox-travis==0.12

--- a/setup.py
+++ b/setup.py
@@ -89,8 +89,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -5,13 +5,11 @@ from __future__ import unicode_literals, absolute_import
 
 import ddt
 from django.contrib.auth.models import User
-from django.db import models
 from django.utils import six
 from rest_framework.test import APIRequestFactory
 
 from freezegun import freeze_time
 
-from config_models.models import ConfigurationModel
 from config_models.views import ConfigurationModelCurrentAPIView
 from example.models import ExampleConfig, ExampleKeyedConfig, ManyToManyExampleConfig
 from .utils import CacheIsolationTestCase
@@ -152,7 +150,7 @@ class ConfigurationModelTests(CacheIsolationTestCase):
 
         second_user = User(username="second_user")
         second_user.save()
-        config.many_user_field.add(second_user)  # pylint: disable=no-member
+        config.many_user_field.add(second_user)
         config.save()
 
         # The many-to-many field is ignored in comparison.
@@ -325,7 +323,6 @@ class KeyedConfigurationModelTests(CacheIsolationTestCase):
                 self.assertEqual(row.left, 'left_b')
                 self.assertEqual(row.string_field, 'first')
                 self.assertEqual(row.is_active, True)
-
 
     def test_equality(self):
         config1 = ExampleKeyedConfig(left='left_a', right='right_a', int_field=1, user=self.user, changed_by=self.user)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,6 +14,7 @@ import copy
 from django.core.cache import caches
 from django.test import TestCase, override_settings
 from django.conf import settings
+from edx_django_utils.cache.utils import TieredCache
 
 
 class CacheIsolationMixin(object):
@@ -107,6 +108,7 @@ class CacheIsolationMixin(object):
         # over our list of overridden caches, instead.
         for cache in settings.CACHES:
             caches[cache].clear()
+        TieredCache.dangerous_clear_all_tiers()
 
 
 class CacheIsolationTestCase(CacheIsolationMixin, TestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,7 @@ from django.conf import settings
 from edx_django_utils.cache.utils import TieredCache
 
 
-class CacheIsolationMixin(object):
+class CacheIsolationMixin:
     """
     This class can be used to enable specific django caches for
     specific the TestCase that it's mixed into.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}-django{111}-drf{39,latest},py{35,36}-django{20,21,22}-drf{39,latest}
+envlist = py{35}-django{111}-drf{39,latest},py{35,36}-django{20,21,22}-drf{39,latest}
 
 [pycodestyle]
 exclude = .git,.tox,migrations


### PR DESCRIPTION
ConfigModels have used a Django cache for a long time (memcached in
practice), but a major performance issue is that these values are
sometimes requested hundreds of times during the course of rendering
a request. Memcached roundtrips are fast, but not free, and for some
courseware rendering views, memcached access can account for over 20%
of the transaction time.

The TieredCache from edx-django-utils uses a request-level cache and
Django cache in combination so that it will only reach out to
memcached once for a given config value in a given request.

This commit also introduces other notable changes:

* Version has been bumped to 2.0.0
* edx-django-utils is now a dependency (for TieredCache)
* Tests have been updated to use CacheIsolationTestCase rather than
mocking out the cache. This simplifies the tests somewhat, and reduces
test reliance on the implementation details of caching. We still
verify that caching happens by database query count.
* We no longer use a dedicated configuration cache setting. The
original idea was that we could have something that was on a different
lifecycle (e.g. process-level). But in practice we always used the
same cache cluster as the default anyway, and using TieredCache gives
us most of the benefit of not having to make so many calls out. This
change lets us remove one more configuration setting.
