### PR TITLE
Python and Django version update in Travis and Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,17 @@
 language: python
 python:
   - 3.5
-  - 3.6
+  - 3.8
 env:
-- TOXENV=django111-drf39
-- TOXENV=django111-drflatest
-- TOXENV=django20-drf39
-- TOXENV=django20-drflatest
-- TOXENV=django21-drf39
-- TOXENV=django21-drflatest
 - TOXENV=django22-drf39
 - TOXENV=django22-drflatest
+- TOXENV=quality
+- TOXENV=docs
 
-matrix:
-  include:
-  - python: 3.5
-    env: TOXENV=quality
-  - python: 3.5
-    env: TOXENV=docs
 cache:
 - pip
 install:
+- pip install pip==20.0.2
 - pip install -r requirements/travis.txt
 script:
 - tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.0.1] - 2020-05-08
+~~~~~~~~~~~~~~~~~~~~
+* Dropped support for Django<2.2
+* Dropped support for python3.6
+* Added support for python3.8
+
 [2.0.0] - 2020-02-06
 ~~~~~~~~~~~~~~~~~~~~
 * Dropping support for Python 2.7

--- a/config_models/__init__.py
+++ b/config_models/__init__.py
@@ -4,6 +4,6 @@ Configuration models for Django allowing config management with auditing.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 default_app_config = 'config_models.apps.ConfigModelsConfig'  # pylint: disable=invalid-name

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,11 +5,11 @@
 #    make upgrade
 #
 django-waffle==0.20.0     # via edx-django-utils
-django==2.2.12            # via -r requirements/base.in, djangorestframework, edx-django-utils
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, djangorestframework, edx-django-utils
 djangorestframework==3.11.0  # via -r requirements/base.in
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in
 newrelic==5.12.0.140      # via edx-django-utils
 psutil==1.2.1             # via edx-django-utils
-pytz==2019.3              # via django
+pytz==2020.1              # via django
 six==1.14.0               # via django-waffle
 sqlparse==0.3.1           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,14 +8,6 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# Sphinx 2.0.0 drops support for python 2.7 which we still need.
-Sphinx<2.0.0
-
-
-# A dependency of pytest.  Pytest doesn't constrain it and 6.0.0 onward
-# only works with python 3
-more-itertools<6.0.0
-
 # We now use TieredCache from edx-django-utils. Putting this constaint just
 # so that we don't get bitten by any backwards-incompatible changes that may
 # happen in v3 of that library.
@@ -25,3 +17,6 @@ edx-django-utils<3
 # Python 3.6+
 twine<2.0
 zipp<2.0
+
+# stay on an lts release
+django<2.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,13 +13,13 @@ caniusepython3==7.2.0     # via -r requirements/quality.txt
 certifi==2020.4.5.1       # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
-click==7.1.1              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
+click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
 codecov==2.0.22           # via -r requirements/travis.txt
 coverage==5.1             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
 ddt==1.3.1                # via -r requirements/quality.txt
 distlib==0.3.0            # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, virtualenv
 django-waffle==0.20.0     # via -r requirements/quality.txt, edx-django-utils
-django==2.2.12            # via -r requirements/quality.txt, djangorestframework, edx-django-utils, edx-i18n-tools
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/quality.txt, djangorestframework, edx-django-utils, edx-i18n-tools
 djangorestframework==3.11.0  # via -r requirements/quality.txt
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/quality.txt
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
@@ -28,17 +28,17 @@ filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 freezegun==0.3.15         # via -r requirements/quality.txt
 idna==2.9                 # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 importlib-metadata==1.6.0  # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-resources, path, pluggy, pytest, tox, virtualenv
-importlib-resources==1.4.0  # via -r requirements/travis.txt, virtualenv
+importlib-resources==1.5.0  # via -r requirements/travis.txt, virtualenv
 isort==4.3.21             # via -r requirements/quality.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
-more-itertools==5.0.0     # via -c requirements/constraints.txt, -r requirements/quality.txt, pytest
+more-itertools==8.2.0     # via -r requirements/quality.txt, pytest
 newrelic==5.12.0.140      # via -r requirements/quality.txt, edx-django-utils
 packaging==20.3           # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, pytest, tox
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
-pip-tools==5.0.0          # via -r requirements/pip-tools.txt
+pip-tools==5.1.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/quality.txt, edx-django-utils
@@ -54,10 +54,10 @@ pytest-cov==2.8.1         # via -r requirements/quality.txt
 pytest-django==3.9.0      # via -r requirements/quality.txt
 pytest==5.4.1             # via -r requirements/quality.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/quality.txt, freezegun
-pytz==2019.3              # via -r requirements/quality.txt, django
+pytz==2020.1              # via -r requirements/quality.txt, django
 pyyaml==5.3.1             # via edx-i18n-tools
 requests==2.23.0          # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, codecov
-six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, django-waffle, edx-i18n-tools, edx-lint, freezegun, more-itertools, packaging, pathlib2, pip-tools, python-dateutil, tox, virtualenv
+six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, django-waffle, edx-i18n-tools, edx-lint, freezegun, packaging, pathlib2, pip-tools, python-dateutil, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.3.1           # via -r requirements/quality.txt, django
 toml==0.10.0              # via -r requirements/travis.txt, tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -7,13 +7,13 @@
 alabaster==0.7.12         # via sphinx
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
-bleach==3.1.4             # via readme-renderer
+bleach==3.1.5             # via readme-renderer
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
 ddt==1.3.1                # via -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils
-django==2.2.12            # via -r requirements/test.txt, djangorestframework, edx-django-utils
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt, djangorestframework, edx-django-utils
 djangorestframework==3.11.0  # via -r requirements/test.txt
 docutils==0.16            # via readme-renderer, sphinx
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/test.txt
@@ -23,9 +23,9 @@ imagesize==1.2.0          # via sphinx
 importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
-more-itertools==5.0.0     # via -c requirements/constraints.txt, -r requirements/test.txt, pytest
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 newrelic==5.12.0.140      # via -r requirements/test.txt, edx-django-utils
-packaging==20.3           # via -r requirements/test.txt, pytest, sphinx
+packaging==20.3           # via -r requirements/test.txt, bleach, pytest, sphinx
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
@@ -37,15 +37,20 @@ pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, freezegun
-pytz==2019.3              # via -r requirements/test.txt, babel, django
-readme-renderer==25.0     # via -r requirements/doc.in, twine
+pytz==2020.1              # via -r requirements/test.txt, babel, django
+readme-renderer==26.0     # via -r requirements/doc.in, twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.23.0          # via requests-toolbelt, sphinx, twine
-six==1.14.0               # via -r requirements/test.txt, bleach, django-waffle, freezegun, more-itertools, packaging, pathlib2, python-dateutil, readme-renderer, sphinx
+six==1.14.0               # via -r requirements/test.txt, bleach, django-waffle, freezegun, packaging, pathlib2, python-dateutil, readme-renderer
 snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.4.3   # via -r requirements/doc.in
-sphinx==1.8.5             # via -c requirements/constraints.txt, -r requirements/doc.in, sphinx-rtd-theme
-sphinxcontrib-websupport==1.2.1  # via sphinx
+sphinx==3.0.3             # via -r requirements/doc.in, sphinx-rtd-theme
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
+sphinxcontrib-jsmath==1.0.1  # via sphinx
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 tqdm==4.45.0              # via twine
 twine==1.15.0             # via -c requirements/constraints.txt, -r requirements/doc.in

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,8 +4,8 @@
 #
 #    make upgrade
 #
-click==7.1.1              # via pip-tools
-pip-tools==5.0.0          # via -r requirements/pip-tools.in
+click==7.1.2              # via pip-tools
+pip-tools==5.1.0          # via -r requirements/pip-tools.in
 six==1.14.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -7,4 +7,3 @@ caniusepython3            # Additional Python 3 compatibility pylint checks
 edx-lint                  # edX pylint rules and plugins
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation
-futures==3.2.0 ; python_version == "2.7"  # via caniusepython3, isort

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,12 +12,12 @@ caniusepython3==7.2.0     # via -r requirements/quality.in
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
-click==7.1.1              # via click-log, edx-lint
+click==7.1.2              # via click-log, edx-lint
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
 ddt==1.3.1                # via -r requirements/test.txt
 distlib==0.3.0            # via caniusepython3
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils
-django==2.2.12            # via -r requirements/test.txt, djangorestframework, edx-django-utils
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt, djangorestframework, edx-django-utils
 djangorestframework==3.11.0  # via -r requirements/test.txt
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/test.txt
 edx-lint==1.4.1           # via -r requirements/quality.in
@@ -27,7 +27,7 @@ importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
-more-itertools==5.0.0     # via -c requirements/constraints.txt, -r requirements/test.txt, pytest
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 newrelic==5.12.0.140      # via -r requirements/test.txt, edx-django-utils
 packaging==20.3           # via -r requirements/test.txt, caniusepython3, pytest
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
@@ -45,9 +45,9 @@ pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, freezegun
-pytz==2019.3              # via -r requirements/test.txt, django
+pytz==2020.1              # via -r requirements/test.txt, django
 requests==2.23.0          # via caniusepython3
-six==1.14.0               # via -r requirements/test.txt, astroid, django-waffle, edx-lint, freezegun, more-itertools, packaging, pathlib2, python-dateutil
+six==1.14.0               # via -r requirements/test.txt, astroid, django-waffle, edx-lint, freezegun, packaging, pathlib2, python-dateutil
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 typed-ast==1.4.1          # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.txt
 freezegun==0.3.15         # via -r requirements/test.in
 importlib-metadata==1.6.0  # via pluggy, pytest
-more-itertools==5.0.0     # via -c requirements/constraints.txt, pytest
+more-itertools==8.2.0     # via pytest
 newrelic==5.12.0.140      # via -r requirements/base.txt, edx-django-utils
 packaging==20.3           # via pytest
 pathlib2==2.3.5           # via pytest
@@ -23,8 +23,8 @@ pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via freezegun
-pytz==2019.3              # via -r requirements/base.txt, django
-six==1.14.0               # via -r requirements/base.txt, django-waffle, freezegun, more-itertools, packaging, pathlib2, python-dateutil
+pytz==2020.1              # via -r requirements/base.txt, django
+six==1.14.0               # via -r requirements/base.txt, django-waffle, freezegun, packaging, pathlib2, python-dateutil
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 wcwidth==0.1.9            # via pytest
 zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -13,7 +13,7 @@ distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-resources==1.5.0  # via virtualenv
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox

--- a/setup.py
+++ b/setup.py
@@ -82,15 +82,12 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35}-django{111}-drf{39,latest},py{35,36}-django{20,21,22}-drf{39,latest}
+envlist = py35-django22-drf{39,latest}, py38-django{22,30}
 
 [pycodestyle]
 exclude = .git,.tox,migrations
@@ -18,13 +18,9 @@ setenv =
     PYTHONPATH = {toxinidir}/mock_apps
     DJANGO_SETTINGS_MODULE = test_settings
 deps =
-    django111: Django>=1.11,<2
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
-    drf37: djangorestframework<3.8.0
-    drf38: djangorestframework<3.9.0
-    drf39: djangorestframework<4.0.0
+    django30: Django>=3.0,<3.1
+    drf39: djangorestframework<3.10.0
     drflatest: djangorestframework
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
**Issue:** [BOM-1566](https://openedx.atlassian.net/browse/BOM-1566)

### Changes in Travis and Tox
- Changed `python36` with `python38`. 
- Removed `django111`, `django20`, `django21`.
- Removed unnecessary constraints and pinned `pip-tools`.
- updated version to `2.0.1`.