### PR TITLE
Unpin tox-battery and run requirements upgrade

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,6 +20,3 @@ zipp<2.0
 
 # stay on an lts release
 django<2.3
-
-# constrained until https://github.com/signalpillar/tox-battery/pull/26 is merged
-tox-battery==0.5.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,7 +35,7 @@ packaging==20.4           # via -r requirements/quality.txt, -r requirements/tra
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
-pip-tools==5.1.2          # via -r requirements/pip-tools.txt
+pip-tools==5.2.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/quality.txt, edx-django-utils
@@ -58,7 +58,7 @@ six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/q
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.3.1           # via -r requirements/quality.txt, django
 toml==0.10.1              # via -r requirements/travis.txt, tox
-tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/travis.txt
+tox-battery==0.6.1        # via -r requirements/travis.txt
 tox-travis==0.12          # via -r requirements/travis.txt
 tox==3.15.1               # via -r requirements/travis.txt, tox-battery, tox-travis
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.2          # via -r requirements/pip-tools.in
+pip-tools==5.2.0          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -21,7 +21,7 @@ pyparsing==2.4.7          # via packaging
 requests==2.23.0          # via codecov
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
-tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/travis.in
+tox-battery==0.6.1        # via -r requirements/travis.in
 tox-travis==0.12          # via -r requirements/travis.in
 tox==3.15.1               # via -r requirements/travis.in, tox-battery, tox-travis
 urllib3==1.25.9           # via requests


### PR DESCRIPTION
tox-battery fix has been merged: https://github.com/signalpillar/tox-battery/pull/26