### PR TITLE
Pin importlib-metadata==1.7.0 for python35

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ django-waffle==2.0.0      # via edx-django-utils
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, djangorestframework, edx-django-utils
 djangorestframework==3.11.1  # via -r requirements/base.in
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in
-newrelic==5.18.0.148      # via edx-django-utils
+newrelic==5.20.0.149      # via edx-django-utils
 psutil==1.2.1             # via edx-django-utils
 pytz==2020.1              # via django
 sqlparse==0.3.1           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,3 +20,6 @@ zipp<2.0
 
 # stay on an lts release
 django<2.3
+
+# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python35
+importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,14 +24,14 @@ edx-lint==1.5.2           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 freezegun==1.0.0          # via -r requirements/quality.txt
 idna==2.10                # via -r requirements/travis.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/quality.txt, -r requirements/travis.txt, path, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, path, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/quality.txt, pytest
 isort==4.3.21             # via -r requirements/quality.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 more-itertools==8.5.0     # via -r requirements/quality.txt, pytest
-newrelic==5.18.0.148      # via -r requirements/quality.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/quality.txt, edx-django-utils
 packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 path.py==12.5.0           # via edx-i18n-tools
 path==13.1.0              # via path.py

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -7,7 +7,7 @@
 alabaster==0.7.12         # via sphinx
 attrs==20.2.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
-bleach==3.2.0             # via readme-renderer
+bleach==3.2.1             # via readme-renderer
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 coverage==5.3             # via -r requirements/test.txt, pytest-cov
@@ -20,12 +20,12 @@ edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements
 freezegun==1.0.0          # via -r requirements/test.txt
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 more-itertools==8.5.0     # via -r requirements/test.txt, pytest
-newrelic==5.18.0.148      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/test.txt, edx-django-utils
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pkginfo==1.5.0.1          # via twine

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,13 +16,13 @@ djangorestframework==3.11.1  # via -r requirements/test.txt
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/test.txt
 edx-lint==1.5.2           # via -r requirements/quality.in
 freezegun==1.0.0          # via -r requirements/test.txt
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 more-itertools==8.5.0     # via -r requirements/test.txt, pytest
-newrelic==5.18.0.148      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/test.txt, edx-django-utils
 packaging==20.4           # via -r requirements/test.txt, pytest
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,10 +10,10 @@ ddt==1.4.1                # via -r requirements/test.in
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.txt
 freezegun==1.0.0          # via -r requirements/test.in
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 more-itertools==8.5.0     # via pytest
-newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/base.txt, edx-django-utils
 packaging==20.4           # via pytest
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,7 +12,7 @@ coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox


### PR DESCRIPTION
- Pinned `importlib-metadata==1.7.0` as `version>1.7.0` is causing conflicts for python35 in running `make upgrade`.
