### PR TITLE
Unpinned importlib-metadata constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,6 +20,3 @@ zipp<2.0
 
 # stay on an lts release
 django<2.3
-
-# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python35
-importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,7 +11,7 @@ certifi==2020.6.20        # via -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
-codecov==2.1.9            # via -r requirements/travis.txt
+codecov==2.1.10           # via -r requirements/travis.txt
 coverage==5.3             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
 ddt==1.4.1                # via -r requirements/quality.txt
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
@@ -24,7 +24,7 @@ edx-lint==1.5.2           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 freezegun==1.0.0          # via -r requirements/quality.txt
 idna==2.10                # via -r requirements/travis.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, path, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.0.0  # via -r requirements/quality.txt, -r requirements/travis.txt, path, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/quality.txt, pytest
 isort==4.3.21             # via -r requirements/quality.txt, pylint
@@ -60,7 +60,7 @@ sqlparse==0.4.1           # via -r requirements/quality.txt, django
 toml==0.10.1              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
 tox-travis==0.12          # via -r requirements/travis.txt
-tox==3.20.0               # via -r requirements/travis.txt, tox-battery, tox-travis
+tox==3.20.1               # via -r requirements/travis.txt, tox-battery, tox-travis
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 urllib3==1.25.10          # via -r requirements/travis.txt, requests
 virtualenv==20.0.33       # via -r requirements/travis.txt, tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -20,7 +20,7 @@ edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements
 freezegun==1.0.0          # via -r requirements/test.txt
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/test.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
@@ -38,7 +38,7 @@ pytest-django==3.10.0     # via -r requirements/test.txt
 pytest==6.1.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, freezegun
 pytz==2020.1              # via -r requirements/test.txt, babel, django
-readme-renderer==26.0     # via -r requirements/doc.in, twine
+readme-renderer==27.0     # via -r requirements/doc.in, twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.24.0          # via requests-toolbelt, sphinx, twine
 six==1.15.0               # via -r requirements/test.txt, bleach, packaging, pathlib2, python-dateutil, readme-renderer

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,7 +16,7 @@ djangorestframework==3.12.1  # via -r requirements/test.txt
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/test.txt
 edx-lint==1.5.2           # via -r requirements/quality.in
 freezegun==1.0.0          # via -r requirements/test.txt
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/test.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ ddt==1.4.1                # via -r requirements/test.in
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.txt
 freezegun==1.0.0          # via -r requirements/test.in
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
 newrelic==5.20.1.150      # via -r requirements/base.txt, edx-django-utils
 packaging==20.4           # via pytest

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,12 +7,12 @@
 appdirs==1.4.4            # via virtualenv
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-codecov==2.1.9            # via -r requirements/travis.in
+codecov==2.1.10           # via -r requirements/travis.in
 coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
+importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -23,7 +23,7 @@ six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
 tox-travis==0.12          # via -r requirements/travis.in
-tox==3.20.0               # via -r requirements/travis.in, tox-battery, tox-travis
+tox==3.20.1               # via -r requirements/travis.in, tox-battery, tox-travis
 urllib3==1.25.10          # via requests
 virtualenv==20.0.33       # via tox
 zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
- `importlib-metadata<2.0.0` was causing conflicts in running `make upgrade` with `python3.5`.
- Unpinned `importlib-metadata` constraint after fixing the issue in https://github.com/pypa/virtualenv/pull/1953 and https://github.com/tox-dev/tox/pull/1682.