### PR TITLE
Update version in prep for push to PyPI.

### DIFF
--- a/config_models/__init__.py
+++ b/config_models/__init__.py
@@ -2,6 +2,6 @@
 Configuration models for Django allowing config management with auditing.
 """
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 
 default_app_config = 'config_models.apps.ConfigModelsConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
We dropped all usage of six and future imports so this should now be pure python 3.x code.  The last release dropped its
dependency on six but was still referencing six in code which was causing issues.