### PR TITLE
Fix deprecated reference of util.memcache.safe_key

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+
+[2.1.1] - 2021-01-28
+~~~~~~~~~~~~~~~~~~~~
+* Fix deprecated reference of ``util.memcache.safe_key``
+
 [2.1.0] - 2021-01-12
 ~~~~~~~~~~~~~~~~~~~~
 * Dropped Python 3.5 Support

--- a/config_models/__init__.py
+++ b/config_models/__init__.py
@@ -2,6 +2,6 @@
 Configuration models for Django allowing config management with auditing.
 """
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 default_app_config = 'config_models.apps.ConfigModelsConfig'  # pylint: disable=invalid-name

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -67,7 +67,7 @@ class CacheIsolationMixin:
                 cache_name: {
                     'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
                     'LOCATION': cache_name,
-                    'KEY_FUNCTION': 'util.memcache.safe_key',
+                    'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
                 } for cache_name in cls.ENABLED_CACHES
             })
 


### PR DESCRIPTION
The correct import path is:
`common.djangoapps.util.memcache.safe_key`.

This is currently broken on Devstack and
stage.edx.org.

This is related to the [import shims removal](https://github.com/edx/edx-platform/pull/25932).