### PR TITLE
fix: remove --no-index flag from pip-compile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,13 @@ upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -r requirements/pip-tools.txt
 	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
-	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
-	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/base.txt requirements/base.in
-	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/test.txt requirements/test.in
-	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/doc.txt requirements/doc.in
-	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/quality.txt requirements/quality.in
-	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/ci.txt requirements/ci.in
-	pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade -o requirements/dev.txt requirements/dev.in
+	pip-compile --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip-compile --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade -o requirements/base.txt requirements/base.in
+	pip-compile --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade -o requirements/test.txt requirements/test.in
+	pip-compile --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade -o requirements/doc.txt requirements/doc.in
+	pip-compile --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade -o requirements/quality.txt requirements/quality.in
+	pip-compile --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade -o requirements/ci.txt requirements/ci.in
+	pip-compile --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django and djangorestframework versions for tests
 	sed -i.tmp '/^[d|D]jango==/d' requirements/test.txt
 	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ django==2.2.19
     #   -r requirements/base.in
     #   djangorestframework
     #   edx-django-utils
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via -r requirements/base.in
 edx-django-utils==2.0.4
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -47,7 +47,7 @@ tox==3.23.0
     #   -r requirements/ci.in
     #   tox-battery
     #   tox-travis
-urllib3==1.26.3
+urllib3==1.26.4
     # via requests
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -68,7 +68,7 @@ django==2.2.19
     #   edx-django-utils
     #   edx-i18n-tools
     #   edx-lint
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via -r requirements/quality.txt
 edx-django-utils==2.0.4
     # via
@@ -76,7 +76,7 @@ edx-django-utils==2.0.4
     #   -r requirements/quality.txt
 edx-i18n-tools==0.5.3
     # via -r requirements/dev.in
-edx-lint==4.1.0
+edx-lint==5.0.0
     # via -r requirements/quality.txt
 filelock==3.0.12
     # via
@@ -93,7 +93,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest
-isort==5.7.0
+isort==5.8.0
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -101,7 +101,7 @@ jinja2==2.11.3
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
     # via
     #   -r requirements/quality.txt
     #   astroid
@@ -131,7 +131,11 @@ pbr==5.5.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==6.0.0
+pep517==0.10.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   pip-tools
+pip-tools==6.0.1
     # via -r requirements/pip-tools.txt
 pluggy==0.13.1
     # via
@@ -153,7 +157,7 @@ py==1.10.0
     #   tox
 pycodestyle==2.7.0
     # via -r requirements/quality.txt
-pydocstyle==5.1.1
+pydocstyle==6.0.0
     # via -r requirements/quality.txt
 pylint-celery==0.3
     # via
@@ -238,7 +242,9 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
+    #   pep517
     #   pylint
     #   pytest
     #   tox
@@ -251,11 +257,11 @@ tox==3.23.0
     #   -r requirements/ci.txt
     #   tox-battery
     #   tox-travis
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   -r requirements/ci.txt
     #   requests
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -16,8 +16,6 @@ bleach==3.3.0
     # via readme-renderer
 certifi==2020.12.5
     # via requests
-cffi==1.14.5
-    # via cryptography
 chardet==4.0.0
     # via requests
 colorama==0.4.4
@@ -26,8 +24,6 @@ coverage==5.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==3.4.6
-    # via secretstorage
 ddt==1.4.2
     # via -r requirements/test.txt
 django-waffle==2.1.0
@@ -40,7 +36,7 @@ django==2.2.19
     #   -r requirements/test.txt
     #   djangorestframework
     #   edx-django-utils
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via -r requirements/test.txt
 docutils==0.16
     # via
@@ -57,18 +53,16 @@ idna==2.10
 imagesize==1.2.0
     # via sphinx
 importlib-metadata==3.7.3
-    # via keyring
+    # via
+    #   keyring
+    #   twine
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-jeepney==0.6.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==2.11.3
     # via sphinx
-keyring==23.0.0
+keyring==23.0.1
     # via twine
 markupsafe==1.1.1
     # via jinja2
@@ -96,8 +90,6 @@ py==1.10.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycparser==2.20
-    # via cffi
 pygments==2.8.1
     # via
     #   readme-renderer
@@ -137,8 +129,6 @@ requests==2.25.1
     #   twine
 rfc3986==1.4.0
     # via twine
-secretstorage==3.3.1
-    # via keyring
 six==1.15.0
     # via
     #   -r requirements/test.txt
@@ -149,7 +139,7 @@ snowballstemmer==2.1.0
     # via sphinx
 sphinx-rtd-theme==0.5.1
     # via -r requirements/doc.in
-sphinx==3.5.2
+sphinx==3.5.3
     # via
     #   -r requirements/doc.in
     #   sphinx-rtd-theme
@@ -175,9 +165,9 @@ toml==0.10.2
     #   pytest
 tqdm==4.59.0
     # via twine
-twine==3.3.0
+twine==3.4.1
     # via -r requirements/doc.in
-urllib3==1.26.3
+urllib3==1.26.4
     # via requests
 webencodings==0.5.1
     # via bleach

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,8 +6,12 @@
 #
 click==7.1.2
     # via pip-tools
-pip-tools==6.0.0
+pep517==0.10.0
+    # via pip-tools
+pip-tools==6.0.1
     # via -r requirements/pip-tools.in
+toml==0.10.2
+    # via pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.36.2
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.0.1
     # via -r requirements/pip.in
-setuptools==54.1.2
+setuptools==54.2.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -39,13 +39,13 @@ django==2.2.19
     #   djangorestframework
     #   edx-django-utils
     #   edx-lint
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via -r requirements/test.txt
 edx-django-utils==2.0.4
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-edx-lint==4.1.0
+edx-lint==5.0.0
     # via -r requirements/quality.in
 freezegun==1.1.0
     # via -r requirements/test.txt
@@ -53,11 +53,11 @@ iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.7.0
+isort==5.8.0
     # via pylint
 jinja2==2.11.3
     # via code-annotations
-lazy-object-proxy==1.5.2
+lazy-object-proxy==1.6.0
     # via astroid
 markupsafe==1.1.1
     # via jinja2
@@ -87,7 +87,7 @@ py==1.10.0
     #   pytest
 pycodestyle==2.7.0
     # via -r requirements/quality.in
-pydocstyle==5.1.1
+pydocstyle==6.0.0
     # via -r requirements/quality.in
 pylint-celery==0.3
     # via edx-lint


### PR DESCRIPTION
### Description
[requirements upgrade build](https://build.testeng.edx.org/job/django-config-models-upgrade-python-requirements/103/console) failed due to `--no-index` flag error. 

### Source
[pip-tools==6.0.0](https://github.com/jazzband/pip-tools/blob/master/CHANGELOG.md#600-2021-03-12) removed `--index/--no-index` flag from [pip-compile](https://github.com/jazzband/pip-tools/pull/1234) command.
`--index/--no-index` flag was [deprecated](https://github.com/jazzband/pip-tools/pull/1130) in [pip-tools==5.2.0](https://github.com/jazzband/pip-tools/blob/master/CHANGELOG.md#520-2020-05-27) in favor of `--emit-index-url/--no-emit-index-url`.