### PR TITLE
Fix review team in upgrade workflow

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -16,7 +16,7 @@ jobs:
 
     with:
       branch: ${{ github.event.inputs.branch }}
-      team_reviewers: "arbi_bom"
+      team_reviewers: "arbi-bom"
       email_address: "arbi-bom@edx.org"
       send_success_notification: false
     secrets:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.4.1
     # via django
-django==3.2.9
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -14,7 +14,7 @@ codecov==2.1.12
     # via -r requirements/ci.in
 coverage==6.2
     # via codecov
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
 filelock==3.4.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -55,11 +55,11 @@ coverage[toml]==6.2
     #   pytest-cov
 ddt==1.4.4
     # via -r requirements/quality.txt
-distlib==0.3.3
+distlib==0.3.4
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.9
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -197,7 +197,7 @@ pytest==6.2.5
     #   pytest-django
 pytest-cov==3.0.0
     # via -r requirements/quality.txt
-pytest-django==4.5.1
+pytest-django==4.5.2
     # via -r requirements/quality.txt
 python-dateutil==2.8.2
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -34,7 +34,7 @@ cryptography==36.0.0
     # via secretstorage
 ddt==1.4.4
     # via -r requirements/test.txt
-django==3.2.9
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -121,7 +121,7 @@ pytest==6.2.5
     #   pytest-django
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-pytest-django==4.5.1
+pytest-django==4.5.2
     # via -r requirements/test.txt
 python-dateutil==2.8.2
     # via
@@ -132,7 +132,7 @@ pytz==2021.3
     #   -r requirements/test.txt
     #   babel
     #   django
-readme-renderer==30.0
+readme-renderer==31.0
     # via
     #   -r requirements/doc.in
     #   twine
@@ -185,7 +185,7 @@ tomli==1.2.2
     #   coverage
 tqdm==4.62.3
     # via twine
-twine==3.7.0
+twine==3.7.1
     # via -r requirements/doc.in
 urllib3==1.26.7
     # via requests

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.37.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.3.1
     # via -r requirements/pip.in
-setuptools==59.5.0
+setuptools==59.6.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -31,7 +31,7 @@ coverage[toml]==6.2
     #   pytest-cov
 ddt==1.4.4
     # via -r requirements/test.txt
-django==3.2.9
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -118,7 +118,7 @@ pytest==6.2.5
     #   pytest-django
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-pytest-django==4.5.1
+pytest-django==4.5.2
     # via -r requirements/test.txt
 python-dateutil==2.8.2
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -54,7 +54,7 @@ pytest==6.2.5
     #   pytest-django
 pytest-cov==3.0.0
     # via -r requirements/test.in
-pytest-django==4.5.1
+pytest-django==4.5.2
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via freezegun


### PR DESCRIPTION
## Description
- Updated review team name from `arbi_bom` to `arbi-bom` to let the upgrade workflow successfully tag the team for review.

## Test
- Tested the new workflow by running the upgrade requirements actions against the branch itself. Upgrade PR was created and the team was tagged successfully this time. Merged the upgrade requirements changes in this PR too and closed the original PR https://github.com/edx/django-config-models/pull/186 which failed to tag the team for review.