### PR TITLE
fix: replace deprecated 'ugettext_lazy' with 'gettext_lazy'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.2.1] - 2021-20-12
+~~~~~~~~~~~~~~~~~~~~
+* Replaced deprecated 'django.utils.translation.ugettext' with 'django.utils.translation.gettext'
+
 [2.2.0] - 2021-07-14
 ~~~~~~~~~~~~~~~~~~~~
 * Added support for django3.2

--- a/config_models/__init__.py
+++ b/config_models/__init__.py
@@ -2,6 +2,6 @@
 Configuration models for Django allowing config management with auditing.
 """
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 
 default_app_config = 'config_models.apps.ConfigModelsConfig'  # pylint: disable=invalid-name

--- a/config_models/admin.py
+++ b/config_models/admin.py
@@ -12,7 +12,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 try:
     cache = caches['configuration']

--- a/config_models/management/commands/populate_model.py
+++ b/config_models/management/commands/populate_model.py
@@ -4,7 +4,7 @@ Populates a ConfigurationModel by deserializing JSON data contained in a file.
 import os
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from config_models.utils import deserialize_json
 

--- a/config_models/models.py
+++ b/config_models/models.py
@@ -11,7 +11,7 @@ from django.conf import settings
 # Django cache.
 from django.core.cache import cache  # pylint: disable=unused-import
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from edx_django_utils.cache.utils import TieredCache
 from rest_framework.utils import model_meta
 


### PR DESCRIPTION
'django.utils.translation.ugettext_lazy' is deprecated in favour of 'django.utils.translation.gettext_lazy' and will be removed in Django 4. 